### PR TITLE
[FIX] Remove deprecated oe_chatter usage (Odoo 18/19)

### DIFF
--- a/skills/odoo-18.0/references/odoo-18-view-guide.md
+++ b/skills/odoo-18.0/references/odoo-18-view-guide.md
@@ -151,6 +151,8 @@ Complete reference for Odoo 18 XML views, actions, menus, and QWeb templates.
 
 ```xml
 <form string="My Record" create="true" edit="true" delete="true">
+    <!-- Chatter (alternative position) -->
+    <chatter>
 
     <!-- Edit-only alerts -->
     <div class="alert alert-warning oe_edit_only" role="alert"
@@ -170,12 +172,6 @@ Complete reference for Odoo 18 XML views, actions, menus, and QWeb templates.
                     <span class="o_stat_text">Confirm</span>
                 </div>
             </button>
-        </div>
-
-        <!-- Chatter -->
-        <div class="oe_chatter">
-            <field name="message_ids"/>
-            <field name="activity_ids"/>
         </div>
 
         <!-- Main content -->
@@ -207,12 +203,8 @@ Complete reference for Odoo 18 XML views, actions, menus, and QWeb templates.
             </page>
         </notebook>
     </sheet>
-
     <!-- Chatter (alternative position) -->
-    <div class="oe_chatter">
-        <field name="message_ids"/>
-        <field name="activity_ids"/>
-    </div>
+        </chatter> 
 </form>
 ```
 
@@ -719,6 +711,7 @@ Complete reference for Odoo 18 XML views, actions, menus, and QWeb templates.
             <field name="arch" type="xml">
                 <form string="My Module" create="true">
                     <sheet>
+                    <chatter>
                         <div class="oe_button_box" name="button_box">
                             <button name="action_confirm" type="object"
                                     string="Confirm" class="oe_stat_button" icon="fa-check"/>
@@ -755,10 +748,7 @@ Complete reference for Odoo 18 XML views, actions, menus, and QWeb templates.
                             </page>
                         </notebook>
                     </sheet>
-                    <div class="oe_chatter">
-                        <field name="message_ids"/>
-                        <field name="activity_ids"/>
-                    </div>
+                    </chatter>
                 </form>
             </field>
         </record>

--- a/skills/odoo-19.0/references/odoo-19-decorator-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-decorator-guide.md
@@ -13,7 +13,7 @@ Guide for using `@api` decorators in Odoo 19: computed fields, validation, oncha
 - [@api.model_create_multi](#apimodel_create_multi)
 - [@api.autovacuum](#apiautovacuum)
 - [@api.private](#apiprivate)
-- [@api_returns](#apireturns)
+- [@api.returns](#apireturns)
 
 ---
 
@@ -367,6 +367,40 @@ def _do_stuff(self):  # Cannot be called from action buttons, but still conventi
 @api.private
 def compute_sensitive_data(self):  # Name doesn't need underscore
     pass
+```
+
+---
+
+---
+
+## @api.returns
+
+**Purpose**: Specify the return model of a method for API compatibility.
+
+```python
+from odoo import api, models
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    @api.returns('res.partner')
+    def get_partner(self):
+        """Returns partner record(s)"""
+        return self.mapped('partner_id')
+
+    @api.returns('self')
+    def copy(self, default=None):
+        """Returns new record(s) of same model"""
+        return super().copy(default)
+```
+
+**Common usage in Odoo base**:
+```python
+# Many methods use @api.returns
+@api.returns('mail.message', lambda value: value.id)
+def message_post(self, ...):
+    # Post a message, return the message
+    return message
 ```
 
 ---

--- a/skills/odoo-19.0/references/odoo-19-view-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-view-guide.md
@@ -153,14 +153,11 @@ Guide for creating views in Odoo 19: list, form, search, kanban, calendar, graph
 
 ```xml
 <form string="My Model">
+    <chatter>
     <sheet>
         <!-- Form content -->
     </sheet>
-    <div class="oe_chatter">
-        <field name="message_follower_ids"/>
-        <field name="activity_ids"/>
-        <field name="message_ids"/>
-    </div>
+    </chatter>
 </form>
 ```
 


### PR DESCRIPTION
This pull request updates the Odoo XML view reference guides for versions 18 and 19 to use the modern `<chatter>` tag instead of the legacy `.oe_chatter` `<div>` for embedding the chatter widget in form views. It also corrects and expands the documentation for the `@api.returns` decorator in Odoo 19, including usage examples and a new section.

**Odoo XML View Modernization:**

* Replaced all instances of the legacy `<div class="oe_chatter">` with the recommended `<chatter>` tag in Odoo 18 and Odoo 19 XML view examples, ensuring up-to-date best practices for embedding the chatter widget. [[1]](diffhunk://#diff-e1745957e28709b39d464a12d64cbafdbd837c9f0dc534f58b40d973a5d65505R154-R155) [[2]](diffhunk://#diff-e1745957e28709b39d464a12d64cbafdbd837c9f0dc534f58b40d973a5d65505L175-L180) [[3]](diffhunk://#diff-e1745957e28709b39d464a12d64cbafdbd837c9f0dc534f58b40d973a5d65505L210-R207) [[4]](diffhunk://#diff-e1745957e28709b39d464a12d64cbafdbd837c9f0dc534f58b40d973a5d65505R714) [[5]](diffhunk://#diff-e1745957e28709b39d464a12d64cbafdbd837c9f0dc534f58b40d973a5d65505L758-R751) [[6]](diffhunk://#diff-33ad22a97037280efa00f1a9b8a73f434957d40341436f215d8d5194de592c1aR156-R160)

**Odoo Python API Decorator Documentation:**

* Fixed the documentation link and section header for `@api.returns` in the Odoo 19 decorator guide, correcting the previous typo `@api_returns` to `@api.returns`.
* Added a new comprehensive section for `@api.returns`, including its purpose, usage examples, and common patterns from Odoo base code.