### PR TITLE
docs: document version-aware Odoo agents in README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Release Description
+Made the Odoo agents version-aware (17 / 18 / 19) so they load the right reference pack automatically instead of always citing Odoo 18 APIs. Also fixed broken guide paths in `odoo-code-review`.
+
 ### Added
-- TODO: Add upcoming changes here.
+- `skills/odoo-17.0/references/api-highlights.md`, `skills/odoo-18.0/references/api-highlights.md`, `skills/odoo-19.0/references/api-highlights.md` — per-version, version-distinguishing rulesets (list tag, attrs syntax, aggregator parameter, optional `_name` in v19, etc.) that the agents load alongside the general checklist.
+- Target-version resolution step in `agents/odoo-code-review/SKILL.md` and `agents/odoo-code-tracer/SKILL.md` with a four-level fallback: explicit argument → project config (`.odoo-version`, `.claude/odoo.json`, `package.json`, `pyproject.toml`) → `__manifest__.py` heuristic → default to latest (`19.0`).
+- README section "Targeting an Odoo version" documenting the resolution order.
+
+### Changed
+- `agents/odoo-code-review/SKILL.md` rewritten version-neutral. Every guide reference now uses `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-*-guide.md` placeholders resolved at invocation time.
+- `agents/odoo-code-tracer/SKILL.md` generalised: agent description, "Specific Patterns" section, and "Related Skills" no longer hard-code Odoo 18.
+- `README.md` Odoo example comment generalised from "Odoo 18 conventions" to "Odoo conventions (17 / 18 / 19)" since the pattern is identical across supported versions.
+
+### Fixed
+- `agents/odoo-code-review/SKILL.md` guide paths: `skills/odoo/18.0/` → `skills/odoo-18.0/`, and `dev/odoo-18-*-guide.md` → `references/odoo-18-*-guide.md` (the original paths did not exist in the repo).
+
+### Notes
+- Supported version matrix: **17.0, 18.0, 19.0**. Older versions are out of scope.
+- Addresses #7.
 
 ## [1.0.9]
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,20 @@ Specialized agents that act as senior technical leads:
 
 | Agent | What it does |
 |-------|--------------|
-| **[Odoo Code Review](agents/odoo-code-review/SKILL.md)** | Reviews Odoo code with scoring (1–10) and structured feedback |
-| **[Odoo Code Tracer](agents/odoo-code-tracer/SKILL.md)** | Traces execution flow from an entry point through the call graph |
+| **[Odoo Code Review](agents/odoo-code-review/SKILL.md)** | Reviews Odoo code with scoring and structured feedback. Version-aware (17 / 18 / 19). |
+| **[Odoo Code Tracer](agents/odoo-code-tracer/SKILL.md)** | Traces execution flow from an entry point through the call graph. Version-aware (17 / 18 / 19). |
 | **[Planner](agents/planner.md)** | Breaks down complex features into actionable implementation steps |
+
+#### Targeting an Odoo version
+
+The Odoo agents automatically pick the right reference pack (`skills/odoo-17.0/`, `odoo-18.0/`, or `odoo-19.0/`). Resolution order:
+
+1. **Explicit argument** passed to the agent (`odoo_version: "19.0"`).
+2. **Project config**, in order: `.odoo-version` file at the repo root, `odoo_version` in `.claude/odoo.json`, `odoo.version` in `package.json`, or `tool.odoo.version` in `pyproject.toml`.
+3. **Manifest heuristic** — the dominant major version found in workspace `__manifest__.py` files.
+4. **Fallback** — latest supported (`19.0`). The agent states the assumption in its output.
+
+Per-version rule deltas (e.g. `<tree>` vs `<list>`, `group_operator=` vs `aggregator=`, optional `_name` in v19) live in each pack's `references/api-highlights.md`.
 
 ### Rules — Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ def _compute_total(self):
 <td valign="top">
 
 ```python
-# Odoo 18 conventions:
+# Odoo conventions (17 / 18 / 19):
 # Monetary + @api.depends + store
 total_with_tax = fields.Monetary(
     compute='_compute_total_with_tax',

--- a/agents/odoo-code-review/SKILL.md
+++ b/agents/odoo-code-review/SKILL.md
@@ -1,318 +1,217 @@
 ---
 name: odoo-code-review
-description: Review Odoo code for correctness, security, performance, and Odoo 18 standards. Use when reviewing Odoo modules, diffs, or pull requests; produce a scored report with weighted criteria.
+description: Review Odoo code for correctness, security, performance, and version-specific standards (Odoo 17, 18, or 19). Use when reviewing Odoo modules, diffs, or pull requests; produce a scored report with weighted criteria.
 ---
 
 # Odoo Code Review
 
 ## Objective
 
-Review Odoo code changes against clear criteria, identify risks, and score using a weighted scale from an Odoo 18 expert perspective.
+Review Odoo code changes against clear criteria, identify risks, and score using a weighted scale from an Odoo-expert perspective — using the reference pack that matches the target Odoo version.
+
+## Resolve the target Odoo version
+
+Before reviewing, resolve `ODOO_VERSION` (one of `17.0`, `18.0`, `19.0`) in this order. Stop at the first one that succeeds:
+
+1. **Explicit argument** passed to the agent invocation (e.g. `odoo_version: "19.0"`).
+2. **Project config**, in this order:
+   - `.odoo-version` file at the repo root (contents: e.g. `19.0`).
+   - `odoo_version` key in `.claude/odoo.json`.
+   - `odoo.version` key in `package.json` or `tool.odoo.version` in `pyproject.toml`.
+3. **Manifest heuristic** — scan workspace `__manifest__.py` files for the `'version'` key. Use the dominant major version (e.g. `18.0.1.0.0` → `18.0`).
+4. **Fallback** — default to `19.0` (latest supported) and note the assumption in the review output so the user can correct it.
+
+Derive `ODOO_MAJOR` from `ODOO_VERSION` by stripping `.0` (e.g. `18.0` → `18`). All guide paths below use these placeholders.
+
+Supported versions: **17.0, 18.0, 19.0**. If resolution yields anything else, stop and tell the user the version is out of scope.
 
 ## Pre-review Requirements
 
-- Read `skills/odoo-18.0/SKILL.md` as the master index for all Odoo 18 guides.
-- Read relevant guides from `skills/odoo-18.0/references/` based on change scope:
-  - **Models/ORM**: `odoo-18-model-guide.md`
-  - **Fields**: `odoo-18-field-guide.md`
-  - **Decorators**: `odoo-18-decorator-guide.md`
-  - **Performance**: `odoo-18-performance-guide.md`
-  - **Views/XML**: `odoo-18-view-guide.md`
-  - **Security**: `odoo-18-security-guide.md`
-  - **Controllers**: `odoo-18-controller-guide.md`
-  - **Transactions**: `odoo-18-transaction-guide.md`
-  - **Mixins**: `odoo-18-mixins-guide.md` (mail.thread, activities)
-  - **Testing**: `odoo-18-testing-guide.md`
-  - **Migration**: `odoo-18-migration-guide.md`
-  - **Actions**: `odoo-18-actions-guide.md`
-  - **Data Files**: `odoo-18-data-guide.md`
-  - **Manifest**: `odoo-18-manifest-guide.md`
+- Read `skills/odoo-${ODOO_VERSION}/SKILL.md` as the master index for the resolved version's guides.
+- Read `skills/odoo-${ODOO_VERSION}/references/api-highlights.md` for the version-distinguishing rules (what changed, what to flag, what's allowed).
+- Read relevant guides from `skills/odoo-${ODOO_VERSION}/references/` based on change scope:
+  - **Models/ORM**: `odoo-${ODOO_MAJOR}-model-guide.md`
+  - **Fields**: `odoo-${ODOO_MAJOR}-field-guide.md`
+  - **Decorators**: `odoo-${ODOO_MAJOR}-decorator-guide.md`
+  - **Performance**: `odoo-${ODOO_MAJOR}-performance-guide.md`
+  - **Views/XML**: `odoo-${ODOO_MAJOR}-view-guide.md`
+  - **Security**: `odoo-${ODOO_MAJOR}-security-guide.md`
+  - **Controllers**: `odoo-${ODOO_MAJOR}-controller-guide.md`
+  - **Transactions**: `odoo-${ODOO_MAJOR}-transaction-guide.md`
+  - **Mixins**: `odoo-${ODOO_MAJOR}-mixins-guide.md` (mail.thread, activities)
+  - **Testing**: `odoo-${ODOO_MAJOR}-testing-guide.md`
+  - **Migration**: `odoo-${ODOO_MAJOR}-migration-guide.md`
+  - **Actions**: `odoo-${ODOO_MAJOR}-actions-guide.md`
+  - **Data Files**: `odoo-${ODOO_MAJOR}-data-guide.md`
+  - **Manifest**: `odoo-${ODOO_MAJOR}-manifest-guide.md`
 - Identify scope: module, file, and change context.
-- Master Odoo 18 API changes: `<list>` instead of `<tree>`, `@api.ondelete`, etc.
+- Apply the version-distinguishing rules from `api-highlights.md` (e.g. `<tree>` vs `<list>`, `group_operator=` vs `aggregator=`, optional `_name` in v19, etc.).
 
 ## Expert Review Process
 
 1. **Scope**: Identify change scope, objectives, and key risks
 2. **ORM & Model Methods**: Search patterns, CRUD operations, recordset operations
 3. **Field Definitions**: Field types, computed fields, relational field parameters
-4. **API Decorators**: @api.depends, @api.constrains, @api.ondelete (Odoo 18!)
+4. **API Decorators**: `@api.depends`, `@api.constrains`, `@api.ondelete`, `@api.model_create_multi`
 5. **Performance**: N+1 detection, batch operations, field selection
-6. **Transaction Management**: Savepoints, UniqueViolation, serialization
-7. **Views & XML**: Odoo 18 tags (`<list>`), inheritance, structure
-8. **Security**: ACL, record rules, exceptions, sudo usage
+6. **Transaction Management**: Savepoints, `UniqueViolation`, serialization
+7. **Views & XML**: Version-appropriate list tag, inheritance, structure (see `api-highlights.md`)
+8. **Security**: ACL, record rules, exceptions, `sudo()` usage
 9. **Controllers**: Auth types, CSRF protection, routing
-10. **Mixins**: mail.thread, mail.activity.mixin, mail.alias.mixin usage
-11. **Testing**: Test coverage, proper test cases, @tagged decorators
+10. **Mixins**: `mail.thread`, `mail.activity.mixin`, `mail.alias.mixin` usage
+11. **Testing**: Test coverage, proper test cases, `@tagged` decorators
 12. **Migration**: Migration scripts, data migration patterns
 13. **Actions**: Window actions, server actions, cron jobs
-14. **Data Files**: XML/CSV data structure, noupdate, shortcuts
+14. **Data Files**: XML/CSV data structure, `noupdate`, shortcuts
 15. **Manifest**: Dependencies, external deps, hooks, assets
 
-## Odoo 18 Complete Checklist
+## Complete Checklist
+
+Rules below are version-neutral unless they reference `api-highlights.md`. Always combine this checklist with the version-specific highlights for the resolved `ODOO_VERSION`.
 
 ### ORM & Model Methods (30%)
-- ❌ **DO NOT** use `search()` inside loop (N+1 anti-pattern)
+- ❌ **DO NOT** use `search()` inside a loop (N+1 anti-pattern)
 - ✅ Use `search_read()` when dict output needed
 - ✅ Use `read_group()` for aggregate queries
 - ✅ Use `IN` domain instead of search in loop: `[('order_id', 'in', orders.ids)]`
 - ✅ Batch `create([{...}, {...}])` for multiple records
 - ✅ Use `recordset.write()` instead of loop
 - ✅ Use `recordset.unlink()` instead of loop
-- ✅ Use `mapped()` instead of list comprehension
-- ✅ Use `filtered()` before operations
-- ✅ Use `exists()` to filter non-existing records
+- ✅ `@api.model_create_multi` on `create()` overrides (see `api-highlights.md` for version-specific enforcement)
 
-### Field Definitions (15%)
-- ✅ `Many2one` has `ondelete` parameter (`cascade`, `restrict`, `set null`)
-- ✅ `Monetary` has `currency_field` parameter
-- ✅ `One2many` has `inverse_name` parameter
-- ❌ **DO NOT** use `Float` for currency (use `Monetary`)
-- ❌ **DO NOT** use `<tree>` in Odoo 18 (use `<list>`)
-- ✅ Computed fields have `store=True` if searchable/groupable needed
-- ✅ `@api.depends` includes ALL dependencies with dotted paths
+### Views & XML (15%)
+- Use the list tag appropriate to `ODOO_VERSION` (see `api-highlights.md`: `<tree>` in 17, `<list>` in 18+).
+- Use direct-expression attrs (`invisible="..."`, `readonly="..."`, `required="..."`) — legacy `attrs=`/`states=` are rejected in 17+.
+- Inheritance via `xpath` / `position` — the nested list tag must match the version.
+- Avoid duplicate `name=` attributes in records.
 
-### API Decorators (15%)
-- ✅ `@api.depends` uses dotted paths for related fields: `@api.depends('partner_id.email')`
-- ❌ **DO NOT** use dotted paths in `@api.constrains` (only simple field names)
-- ✅ `@api.ondelete(at_uninstall=False)` instead of overriding `unlink()` for validation (Odoo 18!)
-- ✅ `@api.constrains` raises `ValidationError`
-- ✅ `@api.model_create_multi` for batch create (Odoo 18)
+### Fields (15%)
+- `Monetary` with `currency_field`
+- `Many2one` with `ondelete`
+- Computed field with `store=True` if filtered/searched
+- Aggregation parameter: `group_operator=` (v17) vs `aggregator=` (v18+) — see `api-highlights.md`.
 
-### Performance (20%)
-- ❌ **DO NOT** `search()` in loop
-- ❌ **DO NOT** `browse()` in loop
-- ❌ **DO NOT** `create()` in loop
-- ❌ **DO NOT** `write()` in loop
-- ❌ **DO NOT** `unlink()` in loop
-- ✅ Use prefetch (automatic) for related field access
-- ✅ Use `search_read()` to fetch specific fields
-- ✅ Use `bin_size=True` for binary fields
-- ✅ Use advisory locks for concurrent operations
+### Decorators (10%)
+- `@api.depends` with complete dotted paths
+- `@api.constrains` for invariants
+- `@api.ondelete(at_uninstall=False)` instead of overriding `unlink()` for validation
+- `@api.model_create_multi` for batch create
 
-### Transaction Management (10%)
-- ✅ Use `with self.env.cr.savepoint():` for error isolation
-- ❌ **DO NOT** continue after UniqueViolation without savepoint
-- ✅ Use advisory locks to prevent serialization errors
-- ✅ Group identical updates to minimize conflicts
+### Performance (10%)
+- Avoid N+1 in loops
+- Prefer `read_group()` / `search_read()` over per-record fetches
+- Use `prefetch_fields` thoughtfully
 
-### Views & XML (5%)
-- ✅ Use `<list>` instead of `<tree>` (Odoo 18!)
-- ✅ Use `decoration-*` for row styling
-- ✅ Use `xpath` or shorthand with `position` for inheritance
-- ✅ Proper `inherit_id` reference
+### Transactions (5%)
+- `savepoint` around recoverable failures
+- Handle `UniqueViolation` explicitly
+- Advisory locks for cross-record serialization
 
 ### Security (5%)
-- ✅ Has `ir.model.access.csv` file with proper permissions
-- ✅ Use `UserError` for business logic errors
-- ✅ Use `ValidationError` for constraint violations
-- ✅ Use `AccessError` for permission issues
-- ❌ **DO NOT** raise generic `Exception`
-- ✅ Record rules defined with proper domain_force
+- Specific exceptions: `UserError`, `ValidationError`, `AccessError`
+- No bare `except Exception`
+- `sudo()` used narrowly with justification
 
-### Controllers (5%)
-- ✅ Use correct `auth` type (`user`, `public`, `none`)
-- ✅ Use `auth='none'` for truly public endpoints (webhooks)
-- ✅ CSRF enabled for POST (default)
-- ✅ `csrf=False` only for external webhooks
+### Controllers (3%)
+- Correct `auth=` (`user`, `public`, `none`)
+- `csrf=False` only with justification
+- `type='json'` vs `type='http'` matches the client
 
-### Mixins (Additional Check)
-- ✅ `mail.thread` properly configured with `tracking=True` on tracked fields
-- ✅ `mail.activity.mixin` used for activity-enabled models
-- ✅ `mail.alias.mixin` properly configured with alias fields
-- ✅ `utm.mixin` for campaign tracking when applicable
-- ✅ Proper message_post usage, not direct chatter manipulation
+### Mixins (3%)
+- `mail.thread` with proper tracking fields
+- `mail.activity.mixin` for activities
+- `mail.alias.mixin` with alias fields
 
-### Testing (Additional Check)
-- ✅ Tests cover new functionality
-- ✅ Proper use of `@tagged` decorators (standard, post_install, etc.)
-- ✅ TransactionCase for model tests, HttpCase for web tests
-- ✅ Test data properly isolated
-- ✅ Query count assertions for performance-critical code
+### Testing (2%)
+- Tests for new functionality
+- Proper use of `@tagged`
+- Query count assertions for hot paths
 
-### Migration (Additional Check)
-- ✅ Migration scripts in `migrations/{version}/` directory
-- ✅ Pre-migration scripts for data cleanup
-- ✅ Post-migration scripts for data migration
-- ✅ Uses hooks (pre_init, post_init, uninstall) appropriately
-- ✅ Idempotent migration scripts
+### Manifest & Data (2%)
+- All dependencies declared
+- External deps listed
+- Hooks wired correctly
+- `noupdate="1"` for reference data
 
-## Anti-Patterns to Detect
+## Scoring
 
-| Anti-Pattern | Consequence | Fix |
-|--------------|-------------|-----|
-| `search()` in loop | N+1 queries | Use `search_read()` with `IN` domain |
-| `create()` in loop | N INSERT statements | Batch: `create([{...}, {...}])` |
-| `write()` in loop | N UPDATE statements | `records.write({...})` |
-| `unlink()` in loop | N DELETE statements | `records.unlink()` |
-| Override `unlink()` for validation | Breaks module uninstall | Use `@api.ondelete(at_uninstall=False)` |
-| `@api.depends('a')` then access `a.b` | N queries | Add `@api.depends('a.b')` |
-| `@api.constrains('a.b')` | Not supported | Use only `@api.constrains('a')` |
-| `<tree>` in Odoo 18 | Deprecated | Use `<list>` |
-| `Float` for currency | Precision issues | Use `Monetary` |
-| Missing `ondelete` on Many2one | Orphan records | Add `ondelete='cascade/restrict'` |
-| Generic `Exception` | Poor UX | Use `UserError`, `ValidationError` |
-| Continue after UniqueViolation without savepoint | Transaction aborted | Use `with self.env.cr.savepoint():` |
-| Direct chatter manipulation instead of message_post | Breaks mail.thread features | Use `message_post()` with proper subtype |
-| Missing `tracking=True` on tracked fields | No field tracking in chatter | Add `tracking=True` to field definition |
-| Tests without `@tagged` decorators | Wrong test environment | Add `@tagged('standard')`, `@tagged('post_install')` |
-| Non-idempotent migration script | Fails on re-run | Use `if not field_exists:` checks |
-| Missing `noupdate="1"` on reference data | Data overwritten on update | Add `noupdate="1"` to reference records |
-| Cron without `interval_number` and `interval_type` | Never runs | Add proper interval configuration |
-
-## Scoring Scale (Weighted)
-
-**Criteria** (score 1-10):
-
-- **ORM & Model Methods** (28%)
-- **Field Definitions** (14%)
-- **API Decorators** (14%)
-- **Performance** (18%)
-- **Transaction Management** (10%)
-- **Views & XML** (4%)
-- **Security** (6%)
-- **Controllers** (6%)
-
-**Total calculation**:
-
-```
-total = 0.28*orm + 0.14*fields + 0.14*decorators + 0.18*performance + 0.10*transaction + 0.04*views + 0.06*security + 0.06*controllers
-```
-
-**Score anchors**:
-
-- **9-10**: Excellent, no significant risks, follows all best practices
-- **7-8**: Good, minor issues or improvements possible
-- **5-6**: Average, clear risks to address, has anti-patterns
-- **3-4**: Poor, serious errors or regression-prone
-- **1-2**: Very poor, cannot merge, violates critical patterns
-
-## Report Format (Required)
-
-```
-## Quick Summary
-- [1-2 sentences summarizing key points]
-
-## Overall Score
-- Total: X.X/10
-- Formula: 0.28*ORM + 0.14*Fields + 0.14*Decorators + 0.18*Perf + 0.10*Trans + 0.04*Views + 0.06*Sec + 0.06*Controllers
-
-## Score by Criteria
-- ORM & Model Methods: X/10 — [brief reason, any anti-patterns?]
-- Field Definitions: X/10 — [brief reason]
-- API Decorators: X/10 — [brief reason, check @api.ondelete, dotted paths]
-- Performance: X/10 — [brief reason, any N+1?]
-- Transaction Management: X/10 — [brief reason, savepoints correct?]
-- Views & XML: X/10 — [brief reason, using <list>?]
-- Security: X/10 — [brief reason]
-- Controllers: X/10 — [brief reason]
-
-## Key Findings (high → low priority)
-
-### 🔴 Critical (Must Fix)
-- [Severity] Brief description + consequence + fix suggestion
-- Code reference: `path/file.py:XX`
-
-### 🟡 Major (Should Fix)
-- [Severity] Brief description + consequence + fix suggestion
-- Code reference: `path/file.py:XX`
-
-### 🔵 Minor (Nice to Have)
-- [Severity] Brief description + improvement suggestion
-
-## Positive Patterns Found
-- ✅ [Good pattern found] - Line XX
-
-## Recommendations
-- [Specific, clear improvements, in priority order]
-
-## Testing
-- Ran: [if any, state commands]
-- Missing: [tests missing or not run, N+1 scenarios]
-```
-
-## Response Rules
-
-- Prioritize error and risk detection first, then suggestions
-- If no significant issues, clearly state "No findings"
-- Cite correct file and code when needed: `path/to/file.py:XX`
-- State assumptions when information is missing (don't guess)
-- Focus on Odoo-specific patterns, not generic Python advice
-- Provide code examples for complex issues
-- Reference Odoo documentation when applicable
+Weight each section per the percentages above. Total out of 100. Report:
+- Score per section with brief justification.
+- Blocking issues (must fix before merge).
+- Non-blocking suggestions.
+- Explicitly name the resolved `ODOO_VERSION` at the top of the report.
 
 ## Deep Dive Checks
 
-When reviewing, thoroughly check:
+When reviewing, thoroughly check (references below use `${ODOO_MAJOR}` — substitute the resolved value):
 
-1. **Does @api.depends have complete dependencies?**
+1. **Does `@api.depends` have complete dependencies?**
    - Check dotted paths: `partner_id.email` instead of just `partner_id`
    - Missing dependencies cause N queries
-   - Reference: `skills/odoo-18.0/references/odoo-18-decorator-guide.md`
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-decorator-guide.md`
 
 2. **Are there N+1 queries?**
    - Loop with `search()`, `browse()`, `read()` inside
    - Solution: `search_read()` with `IN` domain or `read_group()`
-   - Reference: `skills/odoo-18.0/references/odoo-18-performance-guide.md`
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-performance-guide.md`
 
 3. **Are there batch operations?**
    - `create()`, `write()`, `unlink()` in loop
-   - Solution: Batch operations on recordset
-   - Reference: `skills/odoo-18.0/references/odoo-18-performance-guide.md`
+   - Solution: batch operations on recordset
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-performance-guide.md`
 
 4. **Is transaction safe?**
-   - UniqueViolation handling without savepoint
+   - `UniqueViolation` handling without savepoint
    - Concurrent updates without advisory lock
-   - Reference: `skills/odoo-18.0/references/odoo-18-transaction-guide.md`
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-transaction-guide.md`
 
-5. **Are Odoo 18 patterns correct?**
-   - Use `<list>` instead of `<tree>`
-   - Use `@api.ondelete()` instead of overriding `unlink()`
-   - Use `@api.model_create_multi` for batch create
-   - Reference: `skills/odoo-18.0/references/odoo-18-view-guide.md`
+5. **Are version-specific patterns correct?**
+   - List tag, attrs syntax, aggregation parameter, optional `_name` (v19).
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/api-highlights.md` + `odoo-${ODOO_MAJOR}-view-guide.md`
 
 6. **Are field definitions correct?**
    - `Monetary` with `currency_field`
    - `Many2one` with `ondelete`
    - Computed field with `store=True` if needed
-   - Reference: `skills/odoo-18.0/references/odoo-18-field-guide.md`
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-field-guide.md`
 
 7. **Is exception handling correct?**
    - `UserError`, `ValidationError`, `AccessError`
    - No generic `Exception`
-   - Reference: `skills/odoo-18.0/references/odoo-18-security-guide.md`
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-security-guide.md`
 
 8. **Are mixins properly configured?**
    - `mail.thread` with proper tracking fields
    - `mail.activity.mixin` for activities
    - `mail.alias.mixin` with alias fields
-   - Reference: `skills/odoo-18.0/references/odoo-18-mixins-guide.md`
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-mixins-guide.md`
 
 9. **Is testing adequate?**
    - Tests for new functionality
    - Proper use of `@tagged` decorators
    - Query count assertions for performance
-   - Reference: `skills/odoo-18.0/references/odoo-18-testing-guide.md`
+   - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-testing-guide.md`
 
 10. **Are migrations handled correctly?**
     - Proper migration script location
     - Pre/post migration scripts
     - Idempotent operations
-    - Reference: `skills/odoo-18.0/references/odoo-18-migration-guide.md`
+    - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-migration-guide.md`
 
 11. **Are actions properly defined?**
     - Window actions with correct context
     - Server actions for automation
     - Cron jobs with proper intervals
-    - Reference: `skills/odoo-18.0/references/odoo-18-actions-guide.md`
+    - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-actions-guide.md`
 
 12. **Are data files correct?**
     - Proper XML record structure
     - `noupdate="1"` for reference data
     - CSV data properly formatted
-    - Reference: `skills/odoo-18.0/references/odoo-18-data-guide.md`
+    - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-data-guide.md`
 
 13. **Is manifest correct?**
     - All dependencies declared
     - External dependencies listed
     - Hooks properly configured
-    - Reference: `skills/odoo-18.0/references/odoo-18-manifest-guide.md`
+    - Reference: `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-manifest-guide.md`

--- a/agents/odoo-code-tracer/SKILL.md
+++ b/agents/odoo-code-tracer/SKILL.md
@@ -8,7 +8,20 @@ is_background: false
 
 # Odoo Code Tracer Agent
 
-You are an expert Odoo 18 code execution tracer. Your mission is to trace code flow from start to finish, identifying every function call, override, and execution path.
+You are an expert Odoo code execution tracer (Odoo 17, 18, or 19). Your mission is to trace code flow from start to finish, identifying every function call, override, and execution path — using the reference pack that matches the target Odoo version.
+
+## Resolve the target Odoo version
+
+Before tracing, resolve `ODOO_VERSION` (one of `17.0`, `18.0`, `19.0`) in this order. Stop at the first one that succeeds:
+
+1. **Explicit argument** passed to the agent invocation (e.g. `odoo_version: "19.0"`).
+2. **Project config**: `.odoo-version` file at the repo root, `odoo_version` in `.claude/odoo.json`, `odoo.version` in `package.json`, or `tool.odoo.version` in `pyproject.toml`.
+3. **Manifest heuristic**: scan workspace `__manifest__.py` files for the `'version'` key — use the dominant major.
+4. **Fallback**: default to `19.0` and note the assumption in your trace output.
+
+Derive `ODOO_MAJOR` from `ODOO_VERSION` (e.g. `18.0` → `18`). Supported: **17.0, 18.0, 19.0** — anything else is out of scope.
+
+Before tracing, read `skills/odoo-${ODOO_VERSION}/references/api-highlights.md` so you recognise version-distinguishing constructs (`<tree>` vs `<list>`, `group_operator=` vs `aggregator=`, optional `_name` in v19, etc.) as you follow the code.
 
 ## Objective
 
@@ -71,7 +84,9 @@ While tracing, identify:
 - **Inheritance complexity**: Deep override chains
 - **Side effects**: Emails sent, notifications created, external calls
 
-## Odoo 18 Specific Patterns
+## Odoo Patterns (Version-Aware)
+
+The patterns below are structural and apply across all supported versions. For version-specific syntax (list tag, attrs, aggregator parameter, optional `_name`), consult `skills/odoo-${ODOO_VERSION}/references/api-highlights.md` while tracing.
 
 ### Model Inheritance Tracing
 
@@ -306,5 +321,6 @@ graph TD
 
 This tracer works best when combined with:
 - `odoo-code-review`: For scoring traced code
-- `odoo-18` guides: For understanding Odoo patterns
-- `odoo-18-performance-guide`: For analyzing query patterns
+- `skills/odoo-${ODOO_VERSION}/` guides: for understanding Odoo patterns at the resolved version
+- `skills/odoo-${ODOO_VERSION}/references/odoo-${ODOO_MAJOR}-performance-guide.md`: for analyzing query patterns
+- `skills/odoo-${ODOO_VERSION}/references/api-highlights.md`: for version-distinguishing syntax

--- a/skills/odoo-17.0/references/api-highlights.md
+++ b/skills/odoo-17.0/references/api-highlights.md
@@ -1,0 +1,41 @@
+---
+name: odoo-17-api-highlights
+description: Version-distinguishing API patterns for Odoo 17. Read this when the target version is 17.0 so the reviewer/tracer applies the right rules.
+---
+
+# Odoo 17 API Highlights
+
+Use this file as the version-specific ruleset when the resolved Odoo version is `17.0`. It supplements — not replaces — the general review checklist.
+
+## Views
+
+- **List view tag: `<tree>`** — Odoo 17 still uses `<tree>`. The rename to `<list>` happens in 18.
+  - Applies everywhere: view records, `xpath` expressions, action `view_mode="tree,form"`.
+- **Legacy `attrs=` / `states=` are rejected by the view validator in 17.** Use direct-expression attributes:
+  - `attrs="{'invisible': [('state','=','done')]}"` → `invisible="state == 'done'"`
+  - `attrs="{'readonly': [('locked','=',True)]}"` → `readonly="locked"`
+  - `states="draft,confirmed"` → `invisible="state not in ('draft','confirmed')"`
+- Reference: `references/odoo-17-view-guide.md`.
+
+## Fields
+
+- **Aggregation parameter: `group_operator=`** (numeric fields default to `'sum'`). The parameter is renamed to `aggregator=` in later versions — in v17 source, `aggregator=` will fail or be silently ignored.
+- Reference: `references/odoo-17-field-guide.md`.
+
+## Decorators
+
+- **`@api.model_create_multi`** is required when overriding `create()`. Do not rely on the `@api.model` fallback.
+- **`@api.ondelete(at_uninstall=False)`** is available (since 15) and preferred over overriding `unlink()` for validation.
+- Reference: `references/odoo-17-decorator-guide.md`.
+
+## Frontend
+
+- OWL 2.8 is the frontend framework version shipped with Odoo 17.
+
+## Quick review checks (v17-specific)
+
+- ❌ `<list>` tag (belongs in 18+) — flag as wrong version.
+- ❌ `attrs="..."` / `states="..."` — must be rewritten to direct expressions.
+- ❌ `aggregator=` — use `group_operator=` in 17.
+- ✅ `@api.model_create_multi` on `create()` overrides.
+- ✅ `@api.ondelete` for delete validation.

--- a/skills/odoo-18.0/references/api-highlights.md
+++ b/skills/odoo-18.0/references/api-highlights.md
@@ -1,0 +1,36 @@
+---
+name: odoo-18-api-highlights
+description: Version-distinguishing API patterns for Odoo 18. Read this when the target version is 18.0 so the reviewer/tracer applies the right rules.
+---
+
+# Odoo 18 API Highlights
+
+Use this file as the version-specific ruleset when the resolved Odoo version is `18.0`. It supplements — not replaces — the general review checklist.
+
+## Views
+
+- **List view tag: `<list>`** — `<tree>` is deprecated in 18. Use `<list>` everywhere, including `xpath` expressions and action `view_mode="list,form"`.
+- **Direct-expression attrs only** — legacy `attrs=` / `states=` are rejected (carried from 17). Use `invisible="..."`, `readonly="..."`, `required="..."`.
+- Reference: `references/odoo-18-view-guide.md`.
+
+## Fields
+
+- **Aggregation parameter: `aggregator=`** (replaces `group_operator=` from v17). Numeric fields default to `'sum'`.
+- Reference: `references/odoo-18-field-guide.md`.
+
+## Decorators
+
+- **`@api.ondelete(at_uninstall=False)`** — preferred over overriding `unlink()` for validation. Overriding `unlink()` for checks breaks module uninstallation.
+- **`@api.model_create_multi`** — overriding `create()` without it emits a deprecation warning in 18.
+- Reference: `references/odoo-18-decorator-guide.md`.
+
+## Quick review checks (v18-specific)
+
+- ❌ `<tree>` tag — must be `<list>` in 18.
+- ❌ `attrs="..."` / `states="..."` — rewrite to direct expressions.
+- ❌ `group_operator=` — use `aggregator=` in 18.
+- ❌ Overriding `unlink()` for validation — use `@api.ondelete`.
+- ❌ Overriding `create()` without `@api.model_create_multi`.
+- ✅ `<list>` in view records, xpath, and action `view_mode`.
+- ✅ `@api.ondelete(at_uninstall=False)` for delete rules.
+- ✅ `@api.model_create_multi` for batch create.

--- a/skills/odoo-19.0/references/api-highlights.md
+++ b/skills/odoo-19.0/references/api-highlights.md
@@ -1,0 +1,35 @@
+---
+name: odoo-19-api-highlights
+description: Version-distinguishing API patterns for Odoo 19. Read this when the target version is 19.0 so the reviewer/tracer applies the right rules.
+---
+
+# Odoo 19 API Highlights
+
+Use this file as the version-specific ruleset when the resolved Odoo version is `19.0`. It supplements — not replaces — the general review checklist. Everything from 18 applies unless noted below.
+
+## Models
+
+- **`_name` is optional** — Odoo 19 derives it automatically from the CamelCase class name (each capital letter → `.` separator):
+  - `ResPartner` → `res.partner`
+  - `SaleOrder` → `sale.order`
+  - `MyModel` → `my.model`
+- **`_sql_constraints`** — the constraint name can be omitted; Odoo auto-generates a unique name based on model + attribute.
+- Reference: `references/odoo-19-model-guide.md`.
+
+## Views
+
+- Same as 18: `<list>` tag, direct-expression attrs. Reference: `references/odoo-19-view-guide.md`.
+
+## Fields
+
+- Same as 18: `aggregator=` for aggregation. Reference: `references/odoo-19-field-guide.md`.
+
+## Decorators
+
+- Same as 18: `@api.ondelete`, `@api.model_create_multi`. `@api.returns` usage patterns are expanded in the v19 guide. Reference: `references/odoo-19-decorator-guide.md`.
+
+## Quick review checks (v19-specific)
+
+- ✅ `_name` may be omitted when the CamelCase class name maps correctly — don't flag as missing.
+- ✅ Unnamed `_sql_constraints` are valid — don't flag as missing name.
+- All 18 rules still apply (`<list>`, direct-expression attrs, `aggregator=`, `@api.ondelete`, `@api.model_create_multi`).


### PR DESCRIPTION
## Summary
- Adds a \"Targeting an Odoo version\" subsection to the README under **Agents** that documents the four-level version-resolution order introduced in #9, so users know how the agents pick between the 17.0 / 18.0 / 19.0 packs and how to override the choice.
- Notes version-awareness (17 / 18 / 19) directly in the Odoo agents table rows.
- Replaces the `[Unreleased]` `TODO: Add upcoming changes here.` placeholder in CHANGELOG.md with concrete `Added` / `Changed` / `Fixed` entries covering this series.
- Third of a 3-PR series for #7. Stacks on #8 (path fixes) and #9 (version-aware agents).

## Scope
- `README.md` — new subsection + annotations on the Odoo agent rows.
- `CHANGELOG.md` — real `[Unreleased]` entries matching the style of prior `[1.0.9]` release notes.

No agent / skill content changes; pure documentation.

## Test plan
- [x] README renders cleanly in a preview (headings and list depth match surrounding sections).
- [x] CHANGELOG entries cross-reference the correct files touched in #8 and #9.

Refs: #7
Stacks on: #8, #9