### PR TITLE
chore: Release version 1.0.10 with updates for Odoo agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.0.10]
 
 ### Release Description
 Made the Odoo agents version-aware (17 / 18 / 19) so they load the right reference pack automatically instead of always citing Odoo 18 APIs. Also fixed broken guide paths in `odoo-code-review`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unclecat/agent-skills-cli",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "CLI and docs for installing agent skills by version.",
   "bin": {
     "agent-skills": "bin/agent-skills.js"


### PR DESCRIPTION
- Made Odoo agents version-aware (17 / 18 / 19) to load the appropriate reference pack automatically.
- Fixed broken guide paths in `odoo-code-review` to ensure correct navigation.