### PR TITLE
feat: add GitHub Actions workflow for auto-assigning issues

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,27 @@
+name: Auto Assign Issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: auto-assign-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign issue to owner
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['unclecatvn']
+            })


### PR DESCRIPTION
- Introduced a new workflow that automatically assigns newly opened issues to a specified user ('unclecatvn').
- Configured to trigger on issue creation with appropriate permissions and concurrency settings.