### PR TITLE
feat: add Odoo 16 development skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,7 @@
     "skills": [
       "skills/code-review/SKILL.md",
       "skills/dtg-base/SKILL.md",
+      "skills/odoo-16.0/SKILL.md",
       "skills/odoo-17.0/SKILL.md",
       "skills/odoo-18.0/SKILL.md",
       "skills/odoo-19.0/SKILL.md",

--- a/.skillspector-baseline.yaml
+++ b/.skillspector-baseline.yaml
@@ -3,10 +3,6 @@
 version: 1
 rules: []
 fingerprints:
-- hash: sha256:7194e574209afd81
-  rule_id: AS3
-  file: odoo-code-review/agent.md
-  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
 - hash: sha256:ef7a1c37735a98b9
   rule_id: E1
   file: dtg-base/odoo-18-dtg-base-guide.md
@@ -19,7 +15,7 @@ fingerprints:
   rule_id: E1
   file: dtg-base/odoo-18-dtg-base-guide.md
   reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
-- hash: sha256:5780cda56963b9bb
+- hash: sha256:3519bca91401f9ac
   rule_id: EA2
   file: code-review/SKILL.md
   reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
@@ -43,6 +39,14 @@ fingerprints:
   rule_id: MP2
   file: odoo-19.0/SKILL.md
   reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:111438384dd3890a
+  rule_id: PE3
+  file: odoo-16.0/references/odoo-16-mixins-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:fd6639ce43957d1a
+  rule_id: PE3
+  file: odoo-16.0/references/odoo-16-mixins-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
 - hash: sha256:e2e08bc51dd7205a
   rule_id: PE3
   file: odoo-17.0/references/odoo-17-mixins-guide.md
@@ -50,6 +54,90 @@ fingerprints:
 - hash: sha256:aeca703225cf5f81
   rule_id: PE3
   file: odoo-17.0/references/odoo-17-mixins-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:32e895697b1b01bb
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-data-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:4e6508f9747120cf
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-data-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:8c42cfe9776f842a
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-reports-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:08ff2dca898f34d9
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-reports-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:5d08f30ed63bcad0
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-reports-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:b1f0a8671ed545cf
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-reports-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:6406728107e7ac1c
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:50a32710c261f4d5
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:3e292974b5940ab8
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:0a12dc87035a1ce1
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:d8a9da6051a933ac
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:85d95892cb9a581a
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:53e75dc23c99b19c
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:65867e11731b5844
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:04df6fb1d02a81b3
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:ebae99a4cd3c4fc1
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:e9e967f1f85598a1
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:0976b7c11873153f
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:c8327cf9aa7f7e49
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:a9e703caf9558226
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
+  reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
+- hash: sha256:3b17705c01f88d8b
+  rule_id: P2
+  file: odoo-16.0/references/odoo-16-view-guide.md
   reason: 'Accepted: low-confidence doc false-positives + by-design cross-skill composition'
 - hash: sha256:9a4ea2edbce64440
   rule_id: P2

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Think of it as a **"knowledge pack"** — when you add Agent Skills to your proj
 | Generic "how to write a Python function" | Framework-specific "how to write an Odoo 18 model with proper ORM patterns" |
 | AI guesses at framework conventions | AI follows documented best practices |
 | You re-explain project context every session | Context lives in the repo — AI reads it automatically |
-| Subtle bugs from outdated or mixed-version advice | Version-pinned guides (Odoo 17 / 18 / 19) |
+| Subtle bugs from outdated or mixed-version advice | Version-pinned guides (Odoo 16 / 17 / 18 / 19) |
 | Generic security suggestions | Enforced security rules for enterprise applications |
 
 ---
@@ -102,7 +102,7 @@ def _compute_total(self):
 <td valign="top">
 
 ```python
-# Odoo conventions (17 / 18 / 19):
+# Odoo conventions (16 / 17 / 18 / 19):
 # Monetary + @api.depends + store
 total_with_tax = fields.Monetary(
     compute='_compute_total_with_tax',
@@ -132,6 +132,7 @@ In-depth guides written specifically for AI consumption:
 
 | Skill | Description |
 |-------|-------------|
+| **[Odoo 16.0](skills/odoo-16.0/)** | Odoo 16 development (tree views, direct-expression attrs, `group_operator=`, `_sql_constraints`, classic chatter / kanban patterns) |
 | **[Odoo 17.0](skills/odoo-17.0/)** | Odoo 17 development (tree views, direct-expression attrs, `group_operator=`, `_sql_constraints`, JSONB translations, OWL 2.8) |
 | **[Odoo 18.0](skills/odoo-18.0/)** | Odoo 18 development (ORM, views, security, OWL, reports, migrations, performance) |
 | **[Odoo 19.0](skills/odoo-19.0/)** | Odoo 19 development guide with current conventions |
@@ -149,13 +150,13 @@ Specialized agents that act as senior technical leads:
 
 | Agent | What it does |
 |-------|--------------|
-| **[Odoo Code Review](agents/odoo-code-review/SKILL.md)** | Reviews Odoo code with scoring and structured feedback. Version-aware (17 / 18 / 19). |
-| **[Odoo Code Tracer](agents/odoo-code-tracer/SKILL.md)** | Traces execution flow from an entry point through the call graph. Version-aware (17 / 18 / 19). |
+| **[Odoo Code Review](agents/odoo-code-review/SKILL.md)** | Reviews Odoo code with scoring and structured feedback. Version-aware (16 / 17 / 18 / 19). |
+| **[Odoo Code Tracer](agents/odoo-code-tracer/SKILL.md)** | Traces execution flow from an entry point through the call graph. Version-aware (16 / 17 / 18 / 19). |
 | **[Planner](agents/planner.md)** | Breaks down complex features into actionable implementation steps |
 
 #### Targeting an Odoo version
 
-The Odoo agents automatically pick the right reference pack (`skills/odoo-17.0/`, `odoo-18.0/`, or `odoo-19.0/`). Resolution order:
+The Odoo agents automatically pick the right reference pack (`skills/odoo-16.0/`, `odoo-17.0/`, `odoo-18.0/`, or `odoo-19.0/`). Resolution order:
 
 1. **Explicit argument** passed to the agent (`odoo_version: "19.0"`).
 2. **Project config**, in order: `.odoo-version` file at the repo root, `odoo_version` in `.claude/odoo.json`, `odoo.version` in `package.json`, or `tool.odoo.version` in `pyproject.toml`.
@@ -180,6 +181,7 @@ Enforced patterns for consistent, secure code:
 ```
 agent-skills/
 ├── skills/
+│   ├── odoo-16.0/             # Odoo 16 guides
 │   ├── odoo-17.0/             # Odoo 17 guides
 │   ├── odoo-18.0/             # Odoo 18 guides
 │   ├── odoo-19.0/             # Odoo 19 guides
@@ -239,7 +241,7 @@ flowchart LR
 | Metric | Value |
 |--------|-------|
 | Documentation | 55,000+ lines |
-| Skill packs | 10 (Odoo 17.0, 18.0, 19.0, DTG Base, Payment, Code Review, Brainstorming, Writing Skills, MCP Builder, Slide) |
+| Skill packs | 11 (Odoo 16.0, 17.0, 18.0, 19.0, DTG Base, Payment, Code Review, Brainstorming, Writing Skills, MCP Builder, Slide) |
 | Agents | 3 (Odoo Code Review, Odoo Code Tracer, Planner) |
 | License | MIT |
 

--- a/agents/odoo-code-review/SKILL.md
+++ b/agents/odoo-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: odoo-code-review
-description: Review Odoo code for correctness, security, performance, and version-specific standards (Odoo 17, 18, or 19). Use when reviewing Odoo modules, diffs, or pull requests; produce a scored report with weighted criteria.
+description: Review Odoo code for correctness, security, performance, and version-specific standards (Odoo 16, 17, 18, or 19). Use when reviewing Odoo modules, diffs, or pull requests; produce a scored report with weighted criteria.
 ---
 
 # Odoo Code Review
@@ -11,7 +11,7 @@ Review Odoo code changes against clear criteria, identify risks, and score using
 
 ## Resolve the target Odoo version
 
-Before reviewing, resolve `ODOO_VERSION` (one of `17.0`, `18.0`, `19.0`) in this order. Stop at the first one that succeeds:
+Before reviewing, resolve `ODOO_VERSION` (one of `16.0`, `17.0`, `18.0`, `19.0`) in this order. Stop at the first one that succeeds:
 
 1. **Explicit argument** passed to the agent invocation (e.g. `odoo_version: "19.0"`).
 2. **Project config**, in this order:
@@ -23,7 +23,7 @@ Before reviewing, resolve `ODOO_VERSION` (one of `17.0`, `18.0`, `19.0`) in this
 
 Derive `ODOO_MAJOR` from `ODOO_VERSION` by stripping `.0` (e.g. `18.0` → `18`). All guide paths below use these placeholders.
 
-Supported versions: **17.0, 18.0, 19.0**. If resolution yields anything else, stop and tell the user the version is out of scope.
+Supported versions: **16.0, 17.0, 18.0, 19.0**. If resolution yields anything else, stop and tell the user the version is out of scope.
 
 ## Pre-review Requirements
 
@@ -80,8 +80,8 @@ Rules below are version-neutral unless they reference `api-highlights.md`. Alway
 - ✅ `@api.model_create_multi` on `create()` overrides (see `api-highlights.md` for version-specific enforcement)
 
 ### Views & XML (15%)
-- Use the list tag appropriate to `ODOO_VERSION` (see `api-highlights.md`: `<tree>` in 17, `<list>` in 18+).
-- Use direct-expression attrs (`invisible="..."`, `readonly="..."`, `required="..."`) — legacy `attrs=`/`states=` are rejected in 17+.
+- Use the list tag appropriate to `ODOO_VERSION` (see `api-highlights.md`: `<tree>` in 16/17, `<list>` in 18+).
+- Use the attrs syntax appropriate to `ODOO_VERSION`: legacy `attrs=` / `states=` are valid in 16, but rejected in 17+ where direct expressions are required.
 - Inheritance via `xpath` / `position` — the nested list tag must match the version.
 - Avoid duplicate `name=` attributes in records.
 
@@ -89,7 +89,7 @@ Rules below are version-neutral unless they reference `api-highlights.md`. Alway
 - `Monetary` with `currency_field`
 - `Many2one` with `ondelete`
 - Computed field with `store=True` if filtered/searched
-- Aggregation parameter: `group_operator=` (v17) vs `aggregator=` (v18+) — see `api-highlights.md`.
+- Aggregation parameter: `group_operator=` (v16/17) vs `aggregator=` (v18+) — see `api-highlights.md`.
 
 ### Decorators (10%)
 - `@api.depends` with complete dotted paths

--- a/agents/odoo-code-tracer/SKILL.md
+++ b/agents/odoo-code-tracer/SKILL.md
@@ -8,18 +8,18 @@ is_background: false
 
 # Odoo Code Tracer Agent
 
-You are an expert Odoo code execution tracer (Odoo 17, 18, or 19). Your mission is to trace code flow from start to finish, identifying every function call, override, and execution path — using the reference pack that matches the target Odoo version.
+You are an expert Odoo code execution tracer (Odoo 16, 17, 18, or 19). Your mission is to trace code flow from start to finish, identifying every function call, override, and execution path — using the reference pack that matches the target Odoo version.
 
 ## Resolve the target Odoo version
 
-Before tracing, resolve `ODOO_VERSION` (one of `17.0`, `18.0`, `19.0`) in this order. Stop at the first one that succeeds:
+Before tracing, resolve `ODOO_VERSION` (one of `16.0`, `17.0`, `18.0`, `19.0`) in this order. Stop at the first one that succeeds:
 
 1. **Explicit argument** passed to the agent invocation (e.g. `odoo_version: "19.0"`).
 2. **Project config**: `.odoo-version` file at the repo root, `odoo_version` in `.claude/odoo.json`, `odoo.version` in `package.json`, or `tool.odoo.version` in `pyproject.toml`.
 3. **Manifest heuristic**: scan workspace `__manifest__.py` files for the `'version'` key — use the dominant major.
 4. **Fallback**: default to `19.0` and note the assumption in your trace output.
 
-Derive `ODOO_MAJOR` from `ODOO_VERSION` (e.g. `18.0` → `18`). Supported: **17.0, 18.0, 19.0** — anything else is out of scope.
+Derive `ODOO_MAJOR` from `ODOO_VERSION` (e.g. `18.0` → `18`). Supported: **16.0, 17.0, 18.0, 19.0** — anything else is out of scope.
 
 Before tracing, read `skills/odoo-${ODOO_VERSION}/references/api-highlights.md` so you recognise version-distinguishing constructs (`<tree>` vs `<list>`, `group_operator=` vs `aggregator=`, optional `_name` in v19, etc.) as you follow the code.
 

--- a/docs/superpowers/plans/2026-06-20-odoo-16-review-fixes.md
+++ b/docs/superpowers/plans/2026-06-20-odoo-16-review-fixes.md
@@ -1,0 +1,409 @@
+# Odoo 16 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Odoo 17-specific leftovers from the Odoo 16 skill pack so the 16.0 references are trustworthy for agent-generated guidance.
+
+**Architecture:** Treat the review as a documentation-correctness bugfix across a small set of reference guides. Fix the issues by file cluster, replacing incorrect v17 APIs with validated v16 patterns, then run pattern-based verification sweeps to ensure the most dangerous leftovers are gone.
+
+**Tech Stack:** Markdown reference files, `rg`, Git diff, GitHub PR review context
+
+---
+
+## File Map
+
+- `skills/odoo-16.0/references/odoo-16-controller-guide.md`
+  Responsibility: HTTP/controller auth guidance for Odoo 16.
+- `skills/odoo-16.0/references/odoo-16-development-guide.md`
+  Responsibility: Odoo 16 module lifecycle, hooks, structure, and examples.
+- `skills/odoo-16.0/references/odoo-16-manifest-guide.md`
+  Responsibility: manifest keys, hooks, and version metadata guidance.
+- `skills/odoo-16.0/references/odoo-16-model-guide.md`
+  Responsibility: ORM/search/domain/grouping API guidance.
+- `skills/odoo-16.0/references/odoo-16-performance-guide.md`
+  Responsibility: performance guidance, grouping, batching, and SQL patterns.
+- `skills/odoo-16.0/references/odoo-16-decorator-guide.md`
+  Responsibility: decorator reference and supported Odoo 16 API surface.
+- `skills/odoo-16.0/references/odoo-16-security-guide.md`
+  Responsibility: RPC exposure and secure model method guidance.
+- `skills/odoo-16.0/references/odoo-16-actions-guide.md`
+  Responsibility: server action states and XML configuration patterns.
+- `skills/odoo-16.0/references/odoo-16-owl-guide.md`
+  Responsibility: OWL/JS patching, assets, and translation usage for Odoo 16.
+- `skills/odoo-16.0/references/odoo-16-migration-guide.md`
+  Responsibility: upgrade/migration mechanics and version metadata examples.
+
+### Task 1: Capture the current mismatch set
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-06-20-odoo-16-review-fixes.md`
+- Verify: `skills/odoo-16.0/references/*.md`
+
+- [ ] **Step 1: Run a pre-fix sweep for the known Odoo 17 leftovers**
+
+Run:
+
+```powershell
+rg -n "post_init_hook\(env\)|search_fetch|search_count\(.*limit=|aggregates=\[|recordset\.grouped|\.grouped\(|@api\.private|self\.env\._\(|\bany\b|not any|odoo\.tools\.SQL|SQL\.identifier|webhook_url|webhook_field_ids|update_path|version_info = \(17, 0, 0|web\.assets_qweb|patch\(|2\.8\.2|In 17, implement your own bearer-token logic" skills/odoo-16.0/references
+```
+
+Expected: multiple hits in the controller, development, manifest, model, performance, decorator, security, actions, owl, and migration guides.
+
+- [ ] **Step 2: Save the pre-fix evidence in the commit message or PR notes**
+
+Use this summary in the implementation notes:
+
+```text
+Validated the external review locally. The reported Odoo 17 leftovers are present in the Odoo 16 pack and are concentrated in controller, development, manifest, model, performance, decorator, security, actions, owl, and migration guides.
+```
+
+### Task 2: Fix the quick textual leftovers first
+
+**Files:**
+- Modify: `skills/odoo-16.0/references/odoo-16-controller-guide.md`
+- Modify: `skills/odoo-16.0/references/odoo-16-migration-guide.md`
+- Modify: `skills/odoo-16.0/references/odoo-16-manifest-guide.md`
+
+- [ ] **Step 1: Fix the bearer-token typo in the controller guide**
+
+Replace the sentence under `### Odoo 16 does NOT have auth='bearer'`:
+
+```md
+`auth='bearer'` was introduced in later Odoo versions. In 16, implement your own bearer-token logic:
+```
+
+- [ ] **Step 2: Correct leftover `version_info` tuples**
+
+Replace the Odoo 17 tuple references with the Odoo 16 tuple in these guides:
+
+```md
+`version_info = (16, 0, 0, FINAL, 0, '')`
+```
+
+Target files:
+
+```text
+skills/odoo-16.0/references/odoo-16-migration-guide.md
+skills/odoo-16.0/references/odoo-16-manifest-guide.md
+```
+
+- [ ] **Step 3: Verify the quick textual leftovers are gone**
+
+Run:
+
+```powershell
+rg -n "In 17, implement your own bearer-token logic|version_info = \(17, 0, 0" skills/odoo-16.0/references
+```
+
+Expected: no output.
+
+### Task 3: Rewrite hook guidance to real Odoo 16 signatures
+
+**Files:**
+- Modify: `skills/odoo-16.0/references/odoo-16-development-guide.md`
+- Modify: `skills/odoo-16.0/references/odoo-16-manifest-guide.md`
+
+- [ ] **Step 1: Replace env-based hook signatures with `(cr, registry)`**
+
+Use Odoo 16-compatible signatures:
+
+```python
+def pre_init_hook(cr):
+    # optional raw SQL only; no Environment yet
+    pass
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env["ir.config_parameter"].sudo().set_param("business_trip.enabled", "True")
+
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env["ir.config_parameter"].sudo().search([
+        ("key", "=like", "business_trip.%"),
+    ]).unlink()
+```
+
+- [ ] **Step 2: Update the explanatory prose around hook calling conventions**
+
+Make the text say that in Odoo 16:
+
+```md
+- `pre_init_hook` runs before module installation with a cursor-only style entry point.
+- `post_init_hook` and `uninstall_hook` are called with `(cr, registry)`.
+- Build an `Environment` manually inside the hook when ORM access is needed.
+```
+
+- [ ] **Step 3: Verify hook guidance no longer advertises env-only hooks**
+
+Run:
+
+```powershell
+rg -n "def pre_init_hook\(env\)|def post_init_hook\(env\)|def uninstall_hook\(env\)|All three are called with env|called with `env`" skills/odoo-16.0/references/odoo-16-development-guide.md skills/odoo-16.0/references/odoo-16-manifest-guide.md
+```
+
+Expected: no output.
+
+### Task 4: Downgrade the ORM/model guidance to APIs that actually exist in Odoo 16
+
+**Files:**
+- Modify: `skills/odoo-16.0/references/odoo-16-model-guide.md`
+- Modify: `skills/odoo-16.0/references/odoo-16-performance-guide.md`
+
+- [ ] **Step 1: Remove `search_fetch()` as a user-facing Odoo 16 API**
+
+Replace the dedicated `search_fetch()` section with Odoo 16-safe guidance:
+
+```python
+records = self.search([("state", "=", "done")], limit=100)
+records.read(["name", "amount_total", "partner_id"])
+```
+
+And describe `search_read()` without claiming it delegates through a public `search_fetch()` API.
+
+- [ ] **Step 2: Remove `search_count(limit=...)` from the Odoo 16 examples**
+
+Use the v16-safe pattern:
+
+```python
+count = self.search_count([("state", "=", "draft")])
+```
+
+If an upper bound matters, document a separate `search(..., limit=...)` pattern instead of a `search_count(limit=...)` claim.
+
+- [ ] **Step 3: Rewrite `_read_group()` coverage to avoid the v17 `aggregates=[...]` signature**
+
+Replace the v17-style examples with Odoo 16-safe `read_group()` examples:
+
+```python
+rows = self.read_group(
+    domain=[("state", "=", "done")],
+    fields=["partner_id", "amount_total:sum"],
+    groupby=["partner_id"],
+    lazy=False,
+)
+
+amount_by_partner = {
+    row["partner_id"][0]: row["amount_total"]
+    for row in rows
+    if row.get("partner_id")
+}
+```
+
+If `_read_group()` remains documented at all, keep it explicitly caveated as an internal/core method and avoid documenting the v17 named-parameter shape as authoritative Odoo 16 API.
+
+- [ ] **Step 4: Remove `any` / `not any` as supported Odoo 16 domain operators**
+
+Replace that table entry and the dedicated section with relation traversal examples that are valid in Odoo 16:
+
+```python
+domain = [("order_line.product_id.qty_available", "<=", 0)]
+domain = [("order_line.product_id.type", "!=", "service")]
+```
+
+If exact semantics differ from `not any`, prefer a warning that Odoo 16 does not expose the v17 `any` / `not any` operators.
+
+- [ ] **Step 5: Remove `grouped()` as an Odoo 16 recordset API**
+
+Use a plain Python grouping example instead:
+
+```python
+from collections import defaultdict
+
+groups = defaultdict(lambda: self.env[self._name].browse())
+for record in records:
+    groups[record.state] |= record
+```
+
+- [ ] **Step 6: Fix Python translation guidance in the model guide**
+
+Replace:
+
+```python
+translated = self.env._("Hello %s") % name
+```
+
+With:
+
+```python
+from odoo import _
+
+translated = _("Hello %s") % name
+```
+
+- [ ] **Step 7: Verify the model/performance guides no longer advertise the v17 APIs**
+
+Run:
+
+```powershell
+rg -n "search_fetch|search_count\(.*limit=|aggregates=\[|@api\.private|self\.env\._\(|\bany\b|not any|\.grouped\(|recordset\.grouped|SQL\.identifier|odoo\.tools\.SQL" skills/odoo-16.0/references/odoo-16-model-guide.md skills/odoo-16.0/references/odoo-16-performance-guide.md
+```
+
+Expected: no hits for the v17-only APIs. Legitimate uses of the English word "any" outside domain operators are fine and can remain if the search is tightened case-by-case.
+
+### Task 5: Remove unsupported decorator and security guidance
+
+**Files:**
+- Modify: `skills/odoo-16.0/references/odoo-16-decorator-guide.md`
+- Modify: `skills/odoo-16.0/references/odoo-16-security-guide.md`
+
+- [ ] **Step 1: Delete `@api.private` from the Odoo 16 decorator reference**
+
+Remove it from the description, table of contents, section headings, examples, summary table, and source citations.
+
+Replace the guidance with the Odoo 16-safe convention:
+
+```python
+def _refund_total(self, reason):
+    return self.amount_total
+```
+
+And state plainly that underscore-prefixed methods are the standard way to keep helpers out of RPC exposure in Odoo 16.
+
+- [ ] **Step 2: Update the security guide to stop claiming `@api.private` exists in Odoo 16**
+
+Replace the current note with:
+
+```md
+In Odoo 16, keep internal helpers underscore-prefixed so they are not callable through the RPC layer. Do not rely on `@api.private` in this version.
+```
+
+- [ ] **Step 3: Verify the decorator/security guides no longer claim `@api.private` support**
+
+Run:
+
+```powershell
+rg -n "@api\.private|api\.private|_api_private" skills/odoo-16.0/references/odoo-16-decorator-guide.md skills/odoo-16.0/references/odoo-16-security-guide.md
+```
+
+Expected: no output.
+
+### Task 6: Fix server action and OWL guidance to true Odoo 16 patterns
+
+**Files:**
+- Modify: `skills/odoo-16.0/references/odoo-16-actions-guide.md`
+- Modify: `skills/odoo-16.0/references/odoo-16-owl-guide.md`
+
+- [ ] **Step 1: Replace unsupported server action fields/states**
+
+Remove or rewrite the `webhook` state examples and stop documenting `update_path` as the `object_write` configuration surface.
+
+Use v16-safe `fields_lines` guidance instead:
+
+```xml
+<record id="action_mark_done" model="ir.actions.server">
+    <field name="name">Mark Done</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">object_write</field>
+    <field name="fields_lines" eval="[(0, 0, {
+        'col1': ref('base.field_ir_actions_server__fields_lines'),
+        'value': 'done',
+        'type': 'value',
+    })]"/>
+</record>
+```
+
+If the exact `fields_lines` example needs adjustment after source validation, keep the plan intent but use the real Odoo 16 XML shape from upstream docs or source.
+
+- [ ] **Step 2: Rewrite OWL patching examples to the Odoo 16 patch signature**
+
+Replace object-literal `patch(FormController.prototype, { ... super... })` examples with the Odoo 16 pattern:
+
+```javascript
+patch(FormController.prototype, "my_module.FormController", {
+    async onWillSaveRecord(record) {
+        const result = await this._super(...arguments);
+        if (result && record.resModel === "sale.order") {
+            console.log("Saving a sale order");
+        }
+        return result;
+    },
+});
+```
+
+Do the same for the ORM/service patch example and any checklist or summary lines that currently say to use native `super.method(...)`.
+
+- [ ] **Step 3: Correct OWL/assets versioning leftovers**
+
+Update the OWL version text and asset guidance so it no longer claims:
+
+```text
+- OWL 2.8.2
+- web.assets_qweb as a valid Odoo 16 bundle
+```
+
+Keep the replacements source-backed. If exact OWL sub-version is not trivial to verify from the local repo, state the safer form "OWL 2.x shipped with Odoo 16" rather than inventing a number.
+
+- [ ] **Step 4: Verify the server action and OWL leftovers are gone**
+
+Run:
+
+```powershell
+rg -n "webhook_url|webhook_field_ids|update_path|patch\(.*\{|super\.|web\.assets_qweb|2\.8\.2" skills/odoo-16.0/references/odoo-16-actions-guide.md skills/odoo-16.0/references/odoo-16-owl-guide.md
+```
+
+Expected: no output for the removed v17-specific guidance.
+
+### Task 7: Fix raw SQL guidance to remove the v17 `SQL` wrapper
+
+**Files:**
+- Modify: `skills/odoo-16.0/references/odoo-16-performance-guide.md`
+- Modify: `skills/odoo-16.0/references/odoo-16-transaction-guide.md`
+
+- [ ] **Step 1: Replace `odoo.tools.SQL` examples with plain parameterized SQL**
+
+Use Odoo 16-safe cursor examples:
+
+```python
+self.env.cr.execute(
+    "SELECT state, SUM(amount_total) FROM sale_order WHERE state = %s GROUP BY state",
+    ("done",),
+)
+rows = self.env.cr.fetchall()
+```
+
+For dynamic identifiers, do not promise a public `SQL.identifier(...)` helper in v16. Either avoid dynamic identifiers in examples or explicitly label them as cases requiring careful manual quoting outside this guide's scope.
+
+- [ ] **Step 2: Verify the SQL wrapper references are gone**
+
+Run:
+
+```powershell
+rg -n "odoo\.tools\.SQL|SQL\.identifier|cr\.execute\(SQL" skills/odoo-16.0/references/odoo-16-performance-guide.md skills/odoo-16.0/references/odoo-16-transaction-guide.md
+```
+
+Expected: no output.
+
+### Task 8: Final review sweep and commit prep
+
+**Files:**
+- Verify: `skills/odoo-16.0/references/*.md`
+
+- [ ] **Step 1: Re-run the full leftover sweep**
+
+Run:
+
+```powershell
+rg -n "post_init_hook\(env\)|search_fetch|search_count\(.*limit=|aggregates=\[|recordset\.grouped|\.grouped\(|@api\.private|self\.env\._\(|\bany\b|not any|odoo\.tools\.SQL|SQL\.identifier|webhook_url|webhook_field_ids|update_path|version_info = \(17, 0, 0|web\.assets_qweb|2\.8\.2|In 17, implement your own bearer-token logic" skills/odoo-16.0/references
+```
+
+Expected: no remaining hits for the targeted Odoo 17 leftovers. If `\bany\b` still returns normal English prose, refine the search and ensure the domain-operator examples are gone.
+
+- [ ] **Step 2: Review the diff by file cluster**
+
+Run:
+
+```powershell
+git diff -- skills/odoo-16.0/references/odoo-16-controller-guide.md skills/odoo-16.0/references/odoo-16-development-guide.md skills/odoo-16.0/references/odoo-16-manifest-guide.md skills/odoo-16.0/references/odoo-16-model-guide.md skills/odoo-16.0/references/odoo-16-performance-guide.md skills/odoo-16.0/references/odoo-16-decorator-guide.md skills/odoo-16.0/references/odoo-16-security-guide.md skills/odoo-16.0/references/odoo-16-actions-guide.md skills/odoo-16.0/references/odoo-16-owl-guide.md skills/odoo-16.0/references/odoo-16-migration-guide.md skills/odoo-16.0/references/odoo-16-transaction-guide.md
+```
+
+Expected: each change should clearly remove a v17-only claim or replace it with a v16-safe example.
+
+- [ ] **Step 3: Commit with a docs-focused message**
+
+```bash
+git add skills/odoo-16.0/references docs/superpowers/plans/2026-06-20-odoo-16-review-fixes.md
+git commit -m "fix: correct Odoo 16 reference pack version-specific APIs"
+```
+

--- a/skills/odoo-16.0/AGENTS.md
+++ b/skills/odoo-16.0/AGENTS.md
@@ -1,0 +1,45 @@
+# Odoo 16 Documentation - AI Agents Setup
+
+Setup guide for using the Odoo 16 pack with AI coding assistants.
+
+## Quick Start
+
+```bash
+npx skills add unclecatvn/agent-skills
+```
+
+Use `skills/odoo-16.0/SKILL.md` as the entry point, then open the matching guide in `references/`.
+
+## Pack Layout
+
+```
+skills/odoo-16.0/
+|-- SKILL.md
+|-- CLAUDE.md
+|-- AGENTS.md
+`-- references/
+```
+
+## Which Guides Matter Most
+
+- `references/odoo-16-view-guide.md` for XML views, inherited views, chatter, kanban.
+- `references/odoo-16-model-guide.md` for ORM, CRUD, domains, recordsets.
+- `references/odoo-16-field-guide.md` for field definitions and `group_operator=`.
+- `references/odoo-16-decorator-guide.md` for `@api.depends`, `@api.ondelete`, `@api.model_create_multi`.
+- `references/api-highlights.md` for version-distinguishing rules that differ from 17+.
+
+## Key Odoo 16 Conventions
+
+| Concern | Odoo 16 | Newer-version change |
+|---------|---------|----------------------|
+| List view tag | `<tree>` | `<list>` in 18+ |
+| Dynamic attributes | Use `attrs="{...}"` / `states="..."` for client-side dynamic behavior; direct `invisible="..."` is static/context-time only | Direct-expression modifiers become record-reactive in 17+ |
+| Aggregation parameter | `group_operator=` | `aggregator=` in 18+ |
+| Kanban template | `t-name="kanban-box"` | `t-name="card"` in 19 |
+| Chatter in form view | Explicit `<div class="oe_chatter"> ... </div>` | `<chatter/>` shortcut in 18+ |
+
+## Agent Guidance
+
+- Prefer the `attrs` / `states` patterns documented in the 16 view guide for client-side dynamic modifiers; direct `invisible="..."` is valid only for static/context-time visibility.
+- Match the existing addon style when editing 16 code, but check `api-highlights.md` before mass-rewriting XML.
+- Treat `skills/odoo-16.0/references/api-highlights.md` as the authority when 16 and 17 guidance diverge.

--- a/skills/odoo-16.0/CLAUDE.md
+++ b/skills/odoo-16.0/CLAUDE.md
@@ -1,0 +1,49 @@
+# Odoo 16 Development Guide
+
+This file is the short operational guide for agents working on Odoo 16.
+
+> For install/setup notes, see [AGENTS.md](./AGENTS.md).
+
+## Use These Guides
+
+- `references/api-highlights.md` for version-specific differences from 17+.
+- `references/odoo-16-view-guide.md` for XML, inherited views, chatter, kanban.
+- `references/odoo-16-model-guide.md` for ORM and recordset behavior.
+- `references/odoo-16-field-guide.md` for fields and `group_operator=`.
+- `references/odoo-16-decorator-guide.md` for `@api.depends`, `@api.ondelete`, `@api.model_create_multi`.
+
+## Odoo 16 Rules That Matter
+
+| Concern | Odoo 16 rule |
+|---------|--------------|
+| List views | Use `<tree>` |
+| Dynamic attributes | Use `attrs="{...}"` / `states="..."` modifiers |
+| Aggregation | Use `group_operator=` |
+| Delete validation | Prefer `@api.ondelete(at_uninstall=False)` |
+| Batch create | Use `@api.model_create_multi` |
+| Kanban card template | Use `t-name="kanban-box"` |
+| Chatter | Use explicit `<div class="oe_chatter"> ... </div>` |
+
+## Review Heuristics
+
+- Prefer `attrs` / `states` for client-side dynamic view modifiers; direct `invisible="..."` is valid only for static/context-time visibility.
+- Check the view guide before rewriting inherited XML broadly.
+- Flag 18/19-only constructs such as `<list>`, `aggregator=`, `models.Constraint(...)`, or `<chatter/>`.
+
+## Common Safe Defaults
+
+```python
+@api.model_create_multi
+def create(self, vals_list):
+    return super().create(vals_list)
+```
+
+```xml
+<tree string="Records">
+    <field name="name"/>
+</tree>
+```
+
+```xml
+<field name="amount_total" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+```

--- a/skills/odoo-16.0/SKILL.md
+++ b/skills/odoo-16.0/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: odoo-16
+description: >
+  Odoo 16 development reference for Python models and ORM (search, domain, read_group, compute fields),
+  XML/CSV data and views, OWL/JS client code, QWeb reports, security (ACL, record rules, groups),
+  cron and server actions, migrations and module upgrades, tests, i18n, and performance.
+  Use this skill whenever work involves Odoo 16 or custom addons—even if the user only pastes a traceback,
+  mentions addons/ or __manifest__.py, describes form/tree/kanban/XML errors, HTTP controllers, or
+  business rules on models—including building features, fixing bugs, refactoring, or reviewing addon code.
+globs: "**/*.{py,xml,csv,js,ts}"
+---
+
+# Odoo 16 Skill - Master Index
+
+Master index for all Odoo 16 development guides. Read the appropriate guide from `references/` based on your task.
+
+## Quick Reference
+
+| Topic | File | When to Use |
+|-------|------|-------------|
+| Actions | `references/odoo-16-actions-guide.md` | Creating actions, menus, scheduled jobs, server actions |
+| API Decorators | `references/odoo-16-decorator-guide.md` | Using @api decorators, compute fields, validation |
+| Controllers | `references/odoo-16-controller-guide.md` | Writing HTTP endpoints, routes, web controllers |
+| Data Files | `references/odoo-16-data-guide.md` | XML/CSV data files, records, shortcuts |
+| Development | `references/odoo-16-development-guide.md` | Creating modules, manifest, reports, security, wizards |
+| Field Types | `references/odoo-16-field-guide.md` | Defining model fields, choosing field types |
+| Manifest | `references/odoo-16-manifest-guide.md` | __manifest__.py configuration, dependencies, hooks |
+| Migration | `references/odoo-16-migration-guide.md` | Upgrading modules, data migration, version changes |
+| Mixins | `references/odoo-16-mixins-guide.md` | mail.thread, activities, email aliases, tracking |
+| Model Methods | `references/odoo-16-model-guide.md` | Writing ORM queries, CRUD operations, domain filters |
+| OWL Components | `references/odoo-16-owl-guide.md` | Building OWL UI components, hooks, services |
+| Performance | `references/odoo-16-performance-guide.md` | Optimizing queries, fixing slow code, preventing N+1 |
+| Reports | `references/odoo-16-reports-guide.md` | QWeb reports, PDF/HTML, templates, paper formats |
+| Security | `references/odoo-16-security-guide.md` | Access rights, record rules, field permissions |
+| Testing | `references/odoo-16-testing-guide.md` | Writing tests, mocking, assertions, browser testing |
+| Transactions | `references/odoo-16-transaction-guide.md` | Handling database errors, savepoints, UniqueViolation |
+| Translation | `references/odoo-16-translation-guide.md` | Adding translations, localization, i18n |
+| Views & XML | `references/odoo-16-view-guide.md` | Writing XML views, actions, menus, QWeb templates |
+
+## File Structure
+
+```
+skills/odoo-16.0/
+├── SKILL.md                          # This file - master index
+└── references/                       # Development guides
+    ├── odoo-16-actions-guide.md
+    ├── odoo-16-controller-guide.md
+    ├── odoo-16-data-guide.md
+    ├── odoo-16-decorator-guide.md
+    ├── odoo-16-development-guide.md
+    ├── odoo-16-field-guide.md
+    ├── odoo-16-manifest-guide.md
+    ├── odoo-16-migration-guide.md
+    ├── odoo-16-mixins-guide.md
+    ├── odoo-16-model-guide.md
+    ├── odoo-16-owl-guide.md
+    ├── odoo-16-performance-guide.md
+    ├── odoo-16-reports-guide.md
+    ├── odoo-16-security-guide.md
+    ├── odoo-16-testing-guide.md
+    ├── odoo-16-transaction-guide.md
+    ├── odoo-16-translation-guide.md
+    └── odoo-16-view-guide.md
+```
+
+## Base Code Reference (Odoo 16)
+
+All guides are based on analysis of Odoo 16 source code:
+- `odoo/models.py` - ORM implementation
+- `odoo/fields.py` - Field types
+- `odoo/api.py` - Decorators
+- `odoo/http.py` - HTTP layer
+- `odoo/exceptions.py` - Exception types
+- `odoo/tools/translate.py` - Translation system
+- `odoo/addons/base/models/res_lang.py` - Language model
+- `addons/web/static/src/core/l10n/translation.js` - JS translations
+
+## External Documentation
+
+- [Odoo 16 Official Documentation](https://github.com/odoo/documentation/tree/16.0)
+- [Odoo 16 Developer Reference](https://github.com/odoo/documentation/blob/16.0/content/developer/reference/backend/orm.rst)

--- a/skills/odoo-16.0/references/api-highlights.md
+++ b/skills/odoo-16.0/references/api-highlights.md
@@ -1,0 +1,42 @@
+---
+name: odoo-16-api-highlights
+description: Version-distinguishing API patterns for Odoo 16. Read this when the target version is 16.0 so the reviewer/tracer applies the right rules.
+---
+
+# Odoo 16 API Highlights
+
+Use this file as the version-specific ruleset when the resolved Odoo version is `16.0`. It supplements, not replaces, the general review checklist.
+
+## Views
+
+- **List view tag: `<tree>`**. The rename to `<list>` happens in 18.
+- **Use `attrs="{...}"` and `states="..."` modifiers** when `invisible`, `readonly`, `required`, or `column_invisible` must react dynamically to record values in the client.
+  Direct attributes such as `invisible="1"`, `invisible="context.get('default_state')"`, or `invisible="state != 'draft'"` are accepted by Odoo 16, but they are not client-side dynamic modifiers.
+- **Chatter uses the explicit block**, not the `<chatter/>` shortcut from 18+.
+- Reference: `references/odoo-16-view-guide.md`.
+
+## Fields
+
+- **Aggregation parameter: `group_operator=`**. The `aggregator=` parameter is for newer versions.
+- Reference: `references/odoo-16-field-guide.md`.
+
+## Decorators
+
+- **`@api.model_create_multi`** should be used on `create()` overrides.
+- **`@api.ondelete(at_uninstall=False)`** is available and preferred over validation logic in `unlink()`.
+- Reference: `references/odoo-16-decorator-guide.md`.
+
+## Frontend
+
+- Odoo 16 still uses the classic `kanban-box` template name in kanban views.
+
+## Quick Review Checks
+
+- Wrong: `<list>` tag. Use `<tree>` in 16.
+- Wrong: `aggregator=`. Use `group_operator=` in 16.
+- Wrong: `<chatter/>`. Use the explicit chatter block in 16.
+- Risky: relying on direct attributes such as `invisible="state != 'draft'"` for client-side dynamic behavior. Use `attrs` in 16 when it must update as field values change.
+- Correct: direct `invisible="1"` or context-based `invisible="context.get('...')"` for static/context-time visibility.
+- Correct: `attrs="{'invisible': [('state', '!=', 'draft')]}"` and `states="draft,confirmed"`.
+- Correct: `<tree>` in views, xpath targets, and `view_mode`.
+- Correct: `@api.model_create_multi` and `@api.ondelete` are appropriate in 16.

--- a/skills/odoo-16.0/references/odoo-16-actions-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-actions-guide.md
@@ -1,0 +1,817 @@
+---
+name: odoo-16-actions
+description: Complete reference for Odoo 16 actions (ir.actions.*), menus (ir.ui.menu), and scheduled jobs (ir.cron). Covers act_window, act_url, server, report, client actions, menu structure, cron fields, and action bindings.
+globs: "**/*.{py,xml}"
+topics:
+  - Window actions (ir.actions.act_window) with view_mode tree,form
+  - URL actions (ir.actions.act_url)
+  - Server actions (ir.actions.server) states code/object_write/object_create/multi
+  - Report actions (ir.actions.report)
+  - Client actions (ir.actions.client)
+  - Scheduled actions (ir.cron) - interval_type, numbercall, doall
+  - Menus (ir.ui.menu) with menuitem shortcut
+  - Action bindings (binding_model_id, binding_type, binding_view_types)
+when_to_use:
+  - Creating window actions and menus
+  - Writing server actions / automations
+  - Setting up scheduled jobs
+  - Exposing actions / reports in the "Action" or "Print" menu
+  - Building client (JS) actions
+---
+
+# Odoo 16 Actions Guide
+
+Reference for Odoo 16 `ir.actions.*`, `ir.ui.menu`, and `ir.cron`.
+
+## Table of Contents
+
+1. [Action Basics](#action-basics)
+2. [Window Actions (ir.actions.act_window)](#window-actions)
+3. [URL Actions (ir.actions.act_url)](#url-actions)
+4. [Server Actions (ir.actions.server)](#server-actions)
+5. [Report Actions (ir.actions.report)](#report-actions)
+6. [Client Actions (ir.actions.client)](#client-actions)
+7. [Scheduled Actions (ir.cron)](#scheduled-actions)
+8. [Menus (ir.ui.menu)](#menus)
+9. [Action Bindings](#action-bindings)
+10. [Returning Actions From Python](#returning-actions-from-python)
+11. [Quick Reference](#quick-reference)
+
+---
+
+## Action Basics
+
+An action tells the client what to do in response to a user interaction: opening a view, calling server code, printing a report, opening a URL, refreshing the UI, etc.
+
+### Common Shape
+
+Every action record exposes:
+
+| Field | Description |
+|-------|-------------|
+| `type` | Model name (`ir.actions.act_window`, `ir.actions.server`, ...) — implicit via the `model` attribute of `<record>` |
+| `name` | Human-readable label |
+
+From Python, actions can be returned as:
+
+| Form | Meaning |
+|------|---------|
+| `False` | Close any open dialog |
+| string (tag) | Client action tag |
+| `integer` | Database id of an existing `ir.actions.*` record |
+| `dict` | Inline action descriptor, or an action dict loaded via `_for_xml_id(...)` |
+
+---
+
+## Window Actions
+
+`ir.actions.act_window` drives the standard "view a model through one or more views" behaviour.
+
+### Key Fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | Char | Action label (shown in breadcrumbs if `target != 'new'`) |
+| `res_model` | Char (required) | Target model |
+| `view_mode` | Char | Comma-separated view types (no spaces). **v16 default: `tree,form`** |
+| `view_id` | Many2one (`ir.ui.view`) | Specific view to use for the first matching `view_mode` type |
+| `view_ids` | One2many (`ir.actions.act_window.view`) | Fine-grained `(sequence, view_mode, view_id)` list |
+| `search_view_id` | Many2one (`ir.ui.view`) | Specific search view |
+| `res_id` | Integer | Opens a specific record in form mode |
+| `domain` | Char (Python list) | Default domain filter |
+| `context` | Char (Python dict) | Default context (supports `search_default_*`, `default_*`) |
+| `target` | Selection | `current` (default), `new` (dialog), `inline`, `fullscreen`, `main` |
+| `limit` | Integer | List pagination (default 80) |
+| `help` | Html | Nocontent help shown when the list is empty |
+| `binding_model_id` | Many2one (`ir.model`) | Attaches the action to the *Action* menu of another model |
+| `binding_view_types` | Char | `list,form` (default); restricts which views display the binding |
+| `groups_id` | Many2many (`res.groups`) | Restrict visibility |
+
+In Odoo 16, the list view tag used in `view_mode` is `tree`, so the common default is `tree,form`.
+
+### View Types (`VIEW_TYPES`)
+
+Defined in `odoo/addons/base/models/ir_actions.py`:
+
+`tree`, `form`, `graph`, `pivot`, `calendar`, `gantt`, `kanban` — plus `search` and `qweb` recognised by `ir.ui.view`.
+
+### Basic Example
+
+```xml
+<record id="action_my_model" model="ir.actions.act_window">
+    <field name="name">My Records</field>
+    <field name="res_model">my.model</field>
+    <field name="view_mode">tree,kanban,form</field>
+    <field name="domain">[('active','=',True)]</field>
+    <field name="context">{'search_default_my_records': 1, 'default_user_id': uid}</field>
+    <field name="help" type="html">
+        <p class="o_view_nocontent_smiling_face">Create your first record!</p>
+        <p>Start by giving it a name.</p>
+    </field>
+</record>
+```
+
+### Binding a Specific View
+
+```xml
+<record id="action_my_model" model="ir.actions.act_window">
+    <field name="name">Customers</field>
+    <field name="res_model">res.partner</field>
+    <field name="view_mode">tree,form</field>
+    <field name="view_id" ref="view_partner_tree_custom"/>
+    <field name="search_view_id" ref="view_partner_search_custom"/>
+</record>
+```
+
+### Open a Single Record in a Dialog
+
+```xml
+<record id="action_open_wizard" model="ir.actions.act_window">
+    <field name="name">Configure</field>
+    <field name="res_model">my.config.wizard</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+```
+
+### Per-Mode View Ordering with `ir.actions.act_window.view`
+
+When several views of the same type exist, or you want strict ordering, prefer `ir.actions.act_window.view`:
+
+```xml
+<record id="action_sale" model="ir.actions.act_window">
+    <field name="name">Sales</field>
+    <field name="res_model">sale.order</field>
+    <field name="view_mode">tree,kanban,form</field>
+</record>
+
+<record id="action_sale_tree" model="ir.actions.act_window.view">
+    <field name="sequence">1</field>
+    <field name="view_mode">tree</field>
+    <field name="view_id" ref="view_sale_tree_custom"/>
+    <field name="act_window_id" ref="action_sale"/>
+</record>
+
+<record id="action_sale_form" model="ir.actions.act_window.view">
+    <field name="sequence">2</field>
+    <field name="view_mode">form</field>
+    <field name="view_id" ref="view_sale_form_custom"/>
+    <field name="act_window_id" ref="action_sale"/>
+</record>
+```
+
+### Target Values
+
+| Value | Effect |
+|-------|--------|
+| `current` (default) | Replace the main content area; breadcrumb added |
+| `new` | Open in a modal dialog |
+| `inline` | Edit the form inline without a modal (rare) |
+| `fullscreen` | Full-screen takeover |
+| `main` | Replace the main content and reset breadcrumbs |
+
+---
+
+## URL Actions
+
+`ir.actions.act_url` opens a URL in the same tab or a new tab/window.
+
+| Field | Values |
+|-------|--------|
+| `url` | Any absolute/relative URL |
+| `target` | `new` (default), `self` |
+
+```xml
+<record id="action_open_docs" model="ir.actions.act_url">
+    <field name="name">Documentation</field>
+    <field name="url">https://www.odoo.com/documentation/16.0/</field>
+    <field name="target">new</field>
+</record>
+```
+
+Returned from Python:
+
+```python
+return {
+    'type': 'ir.actions.act_url',
+    'url': '/web/binary/download?attachment_id=%s' % attachment.id,
+    'target': 'self',
+}
+```
+
+---
+
+## Server Actions
+
+`ir.actions.server` runs server-side logic. The `state` field selects the flavour:
+
+| `state` | Purpose |
+|---------|---------|
+| `code` | Execute a Python snippet |
+| `object_create` | Create a record of `crud_model_id` from the current context |
+| `object_write` | Update the current record (or records) |
+| `multi` | Run a list of other server actions sequentially (`child_ids`) |
+
+(See `odoo/addons/base/models/ir_actions.py::ServerActions`.)
+
+### `code` — Run Python
+
+```xml
+<record id="action_server_notify" model="ir.actions.server">
+    <field name="name">Notify Owner</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">code</field>
+    <field name="code">
+if records:
+    for record in records:
+        record.message_post(body="Processed via server action")
+action = {
+    'type': 'ir.actions.client',
+    'tag': 'display_notification',
+    'params': {
+        'title': 'Done',
+        'message': '%d record(s) processed' % len(records),
+        'type': 'success',
+    },
+}
+    </field>
+</record>
+```
+
+#### `code` Evaluation Context
+
+| Name | Description |
+|------|-------------|
+| `env` | Current environment |
+| `model` | `env[model_id.model]` |
+| `record` | Current record, if any (may be empty) |
+| `records` | Recordset the action is run on |
+| `action` | Assign here to return a follow-up action |
+| `log(msg, level='info')` | Writes into `ir.logging` |
+| `Warning` | `UserError` constructor (aliased for legacy compat) |
+| `datetime`, `dateutil`, `time`, `timezone`, `UserError`, `float_compare` | Python helpers |
+
+This is the core evaluation context you will use most often, not an exhaustive list of every helper available through Odoo's safe-eval environment.
+
+Odoo 16's core server-action model exposes these four states in `ir.actions.server`. If you need to call an external HTTP service, use `state="code"` (or a cron) to invoke trusted Python code instead of relying on undocumented outbound-HTTP action fields.
+
+### `object_write` — Update Record
+
+In Odoo 16, value updates are described with `fields_lines` (`ir.server.object.lines`) rather than a single path/value shortcut.
+
+```xml
+<record id="action_mark_done" model="ir.actions.server">
+    <field name="name">Mark Done</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">object_write</field>
+    <field name="fields_lines" eval="[
+        (0, 0, {
+            'col1': ref('my_module.field_my_model__state'),
+            'evaluation_type': 'value',
+            'value': 'done',
+        }),
+    ]"/>
+</record>
+```
+
+Useful `fields_lines` fields in Odoo 16:
+
+| Field | Purpose |
+|-------|---------|
+| `col1` | Target `ir.model.fields` record to write |
+| `evaluation_type` | `value`, `reference`, or `equation` |
+| `value` | Raw value, referenced record id, or Python expression depending on `evaluation_type` |
+
+### `object_create` — Create a Record
+
+```xml
+<record id="action_spawn_task" model="ir.actions.server">
+    <field name="name">Create Task</field>
+    <field name="model_id" ref="model_res_partner"/>
+    <field name="state">object_create</field>
+    <field name="crud_model_id" ref="project.model_project_task"/>
+    <field name="link_field_id" ref="project.field_project_task__partner_id"/>
+    <field name="fields_lines" eval="[
+        (0, 0, {
+            'col1': ref('project.field_project_task__name'),
+            'evaluation_type': 'equation',
+            'value': \"record.name and ('Task for %s' % record.name) or 'Task'\",
+        }),
+    ]"/>
+</record>
+```
+
+### `multi` — Chain Actions
+
+```xml
+<record id="action_multi" model="ir.actions.server">
+    <field name="name">Process &amp; Notify</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">multi</field>
+    <field name="child_ids" eval="[(6, 0, [
+        ref('action_mark_done'),
+        ref('action_server_notify'),
+    ])]"/>
+</record>
+```
+
+### Calling External Services Conservatively
+
+For Odoo 16 modules, keep outgoing HTTP logic in Python code you own and call it from a `code` server action or cron job:
+
+```xml
+<record id="action_push_external" model="ir.actions.server">
+    <field name="name">Push to External System</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">code</field>
+    <field name="code">
+if records:
+    records._push_to_external_system()
+    </field>
+</record>
+```
+
+That keeps retries, authentication, logging, and error handling in regular model code instead of undocumented action fields.
+
+### Common Server-Action Fields
+
+| Field | Purpose |
+|-------|---------|
+| `model_id` | Model the action is declared on |
+| `crud_model_id` | (object_create) target model to create |
+| `link_field_id` | (object_create) auto-link the new record to `record` via this field |
+| `child_ids` | (multi) ordered list of sub-actions |
+| `fields_lines` | (object_write/object_create) value mappings evaluated into the write/create payload |
+| `code` | (code) Python source |
+
+---
+
+## Report Actions
+
+`ir.actions.report` prints a QWeb template.
+
+### Key Fields
+
+| Field | Notes |
+|-------|-------|
+| `name` | Default file name if `print_report_name` is empty |
+| `model` | Required — the model the report is about |
+| `report_type` | `qweb-pdf`, `qweb-html`, `qweb-text` (default `qweb-pdf`) |
+| `report_name` | External id of the QWeb template (required) |
+| `report_file` | Base name for generated files (without extension) |
+| `print_report_name` | Python expression using `object` (one record) for the file name |
+| `paperformat_id` | Defaults to the company's paperformat |
+| `attachment_use` | If True, reuse saved attachment instead of regenerating |
+| `attachment` | Python expression producing the attachment filename |
+| `binding_model_id` | Bind to the model's *Print* menu |
+| `binding_type` | `'report'` (default for `ir.actions.report`) |
+| `groups_id` | Restrict by group |
+
+### XML Record
+
+```xml
+<record id="action_report_my_model" model="ir.actions.report">
+    <field name="name">My Model Report</field>
+    <field name="model">my.model</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">my_module.report_my_model_template</field>
+    <field name="report_file">my_module.report_my_model</field>
+    <field name="print_report_name">'Report - %s' % (object.name or '')</field>
+    <field name="binding_model_id" ref="model_my_model"/>
+    <field name="paperformat_id" ref="base.paperformat_euro"/>
+</record>
+```
+
+### `<report>` Shortcut
+
+Equivalent to the record above but shorter. Odoo 16 still accepts `<report>`, but `odoo/tools/convert.py` marks the shortcut deprecated, so prefer `<record model="ir.actions.report">` in new data files:
+
+```xml
+<report
+    id="action_report_my_model"
+    string="My Model Report"
+    model="my.model"
+    report_type="qweb-pdf"
+    name="my_module.report_my_model_template"
+    file="my_module.report_my_model"
+    print_report_name="'Report - %s' % (object.name or '')"
+    attachment_use="False"/>
+```
+
+The shortcut automatically sets `binding_model_id` to the given `model` and `binding_type='report'`, so the action appears under the model's *Print* menu.
+
+---
+
+## Client Actions
+
+`ir.actions.client` triggers a JS-side action registered via `registry.category('actions')`.
+
+| Field | Description |
+|-------|-------------|
+| `tag` | Registered client action identifier |
+| `params` | Arbitrary dict passed to the JS handler |
+| `target` | `current`, `new`, `fullscreen`, `main` |
+
+```xml
+<record id="action_open_dashboard" model="ir.actions.client">
+    <field name="name">Dashboard</field>
+    <field name="tag">my_module.dashboard</field>
+    <field name="params" eval="{'filter': 'my_open'}"/>
+</record>
+```
+
+Commonly used built-in tags:
+
+| Tag | Effect |
+|-----|--------|
+| `reload` | Reload the entire web client |
+| `reload_context` | Refresh the session context, then reload the whole web client; useful after context-changing operations such as switching language/company |
+| `soft_reload` | Soft reload without losing breadcrumbs |
+| `display_notification` | Show a toast (pass `params`: `title`, `message`, `type`, `sticky`) |
+| `home` | Go back to the home menu |
+| `pos.ui` | Launch the Point of Sale UI when the POS addon is installed (addon-dependent) |
+
+Example from Python:
+
+```python
+return {
+    'type': 'ir.actions.client',
+    'tag': 'display_notification',
+    'params': {
+        'title': 'Success',
+        'message': 'Data imported',
+        'type': 'success',      # 'info', 'warning', 'danger', 'success'
+        'sticky': False,
+        'next': {'type': 'ir.actions.act_window_close'},
+    },
+}
+```
+
+---
+
+## Scheduled Actions
+
+`ir.cron` schedules the execution of an `ir.actions.server` on an interval. Internally `ir.cron` *delegates* to a related `ir.actions.server` (`ir_actions_server_id`), so every scheduled job is also a server action.
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` (via `ir_actions_server_id`) | Job name |
+| `user_id` | User whose permissions drive execution; the model default follows the current environment user, though many XML declarations set this explicitly to `base.user_root` |
+| `active` | `True` to enable |
+| `interval_number` | Integer, combined with `interval_type` |
+| `interval_type` | `minutes`, `hours`, `days`, `weeks`, `months` |
+| `numbercall` | Remaining number of executions; `-1` = unlimited (v16 still uses this) |
+| `doall` | If `True`, catch up on missed occurrences after downtime |
+| `nextcall` | Next planned execution datetime |
+| `priority` | Integer, lower runs first when several jobs are due (default 5) |
+| `model_id` | Model the underlying server action runs on |
+| `code` | Python snippet (same context as a `code` server action) |
+| `state` | Mirror of the server action `state` — typically `code` for crons |
+
+### Declaration
+
+```xml
+<record id="ir_cron_my_job" model="ir.cron">
+    <field name="name">My Module: Daily Sync</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">code</field>
+    <field name="code">model._cron_daily_sync()</field>
+    <field name="user_id" ref="base.user_root"/>
+    <field name="interval_number">1</field>
+    <field name="interval_type">days</field>
+    <field name="numbercall">-1</field>
+    <field name="doall" eval="False"/>
+    <field name="active" eval="True"/>
+    <field name="priority">10</field>
+</record>
+```
+
+Wrap in `<data noupdate="1">` if users are allowed to tweak the schedule:
+
+```xml
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_my_job" model="ir.cron">
+            ...
+        </record>
+    </data>
+</odoo>
+```
+
+### `interval_type` Values
+
+Defined in `odoo/addons/base/models/ir_cron.py`:
+
+`minutes`, `hours`, `days`, `weeks`, `months`.
+
+(`weeks` and `months` are computed with `dateutil.relativedelta`, so a "1 month" cron fired on Jan 31 will land on Feb 28/29.)
+
+### Writing Cron Code
+
+```python
+class MyModel(models.Model):
+    _name = 'my.model'
+
+    @api.model
+    def _cron_daily_sync(self):
+        # Process records in batches to keep the worker responsive
+        limit = 500
+        to_do = self.search([('sync_required', '=', True)], limit=limit)
+        to_do.action_sync()
+        # Let the scheduler continue if work remains
+        if len(to_do) == limit:
+            self.env.ref('my_module.ir_cron_my_job')._trigger()   # re-run this cron ASAP
+```
+
+Good practices:
+
+- Always use `@api.model` and operate on explicit recordsets (never `self`).
+- Batch work and signal remaining effort by re-triggering the specific cron record when more work remains.
+- Catch exceptions locally if one bad record should not poison the rest; otherwise let the exception propagate so the transaction rolls back and Odoo logs the cron error.
+- Many XML examples set the cron user to `OdooBot` (`base.user_root`) explicitly; choose a user with the access your job needs.
+
+### Triggering a Cron From Code
+
+```python
+cron = self.env.ref('my_module.ir_cron_my_job')
+cron._trigger()                                  # runs as soon as possible
+cron._trigger(at=datetime(2026, 1, 1, 3, 0))     # schedule a one-off extra run
+```
+
+### Failure Handling (v16)
+
+- An uncaught exception rolls back that run and is logged by Odoo.
+- Persistent failures are visible in the job log; administrators can deactivate the cron from the UI.
+- Follow-up execution then depends on the normal schedule or any explicit `_trigger()` call; avoid assuming an immediate automatic retry.
+- Setting `numbercall` to a positive integer runs the job N times and then auto-deactivates; `-1` runs indefinitely.
+
+---
+
+## Menus
+
+Menus live in `ir.ui.menu`. The usual way to create them is the `<menuitem>` shortcut (see the data-files guide for details).
+
+### Minimal Tree
+
+```xml
+<!-- Top-level app menu -->
+<menuitem id="menu_my_module_root"
+          name="My Module"
+          sequence="50"
+          web_icon="my_module,static/description/icon.png"/>
+
+<!-- First-level -->
+<menuitem id="menu_my_records"
+          name="Records"
+          parent="menu_my_module_root"
+          action="action_my_model"
+          sequence="10"/>
+
+<!-- Second-level -->
+<menuitem id="menu_reporting"
+          name="Reporting"
+          parent="menu_my_module_root"
+          sequence="90"/>
+<menuitem id="menu_report_analysis"
+          name="Analysis"
+          parent="menu_reporting"
+          action="action_report_analysis"
+          sequence="10"/>
+```
+
+### Attributes Recap
+
+| Attribute | Purpose |
+|-----------|---------|
+| `id` | External ID |
+| `name` | Visible label |
+| `parent` | Parent menu external ID |
+| `action` | External ID of any action (`act_window`, `server`, `client`, `url`, ...) |
+| `sequence` | Integer, lower first (default 10) |
+| `groups` | Comma-separated group ids; prefix `-` to hide from a group |
+| `web_icon` | `module,path/to/icon.png` — only meaningful on top-level app menus |
+| `active` | `True`/`False` |
+
+The `<menuitem>` shortcut automatically copies the action's `name` onto the menu if you don't set one (see `convert.py::_tag_menuitem`).
+
+### Security
+
+Menus are filtered using the `groups_id` of both the menu and the referenced action. To hide a menu from a specific group, use `-group.xml_id`:
+
+```xml
+<menuitem id="menu_admin_tools"
+          name="Admin Tools"
+          parent="menu_my_module_root"
+          action="action_admin_tools"
+          groups="base.group_system,-base.group_portal"/>
+```
+
+### `web_icon` Asset
+
+For top-level application menus, `web_icon` points to a PNG inside the module. The standard location is `static/description/icon.png`. Sub-menus do not need a `web_icon`.
+
+---
+
+## Action Bindings
+
+Any `ir.actions.*` can be "bound" to a model, making it appear in the *Action* or *Print* menu of that model's list/form views.
+
+| Field | Description |
+|-------|-------------|
+| `binding_model_id` | `ir.model` ref — where the action is displayed |
+| `binding_type` | `action` (default) or `report` |
+| `binding_view_types` | Where in the UI: `list` / `form` / `list,form` (default) |
+
+### Server Action Binding (Action Menu)
+
+```xml
+<record id="action_bulk_archive" model="ir.actions.server">
+    <field name="name">Archive Selected</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">code</field>
+    <field name="code">records.action_archive()</field>
+    <field name="binding_model_id" ref="model_my_model"/>
+    <field name="binding_type">action</field>
+    <field name="binding_view_types">list</field>
+</record>
+```
+
+### Report Binding (Print Menu)
+
+```xml
+<record id="action_report_invoice_custom" model="ir.actions.report">
+    <field name="name">Custom Invoice</field>
+    <field name="model">account.move</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">my_module.report_invoice_custom</field>
+    <field name="binding_model_id" ref="account.model_account_move"/>
+    <!-- binding_type = 'report' is set automatically for ir.actions.report -->
+</record>
+```
+
+### `binding_view_types` Values
+
+| Value | Where shown |
+|-------|-------------|
+| `list` | Only in the list view (after selecting records) |
+| `form` | Only in the form view (for the current record) |
+| `list,form` | Default — both views |
+
+---
+
+## Returning Actions From Python
+
+### Open a Form View
+
+```python
+def action_open_partner(self):
+    self.ensure_one()
+    return {
+        'type': 'ir.actions.act_window',
+        'name': 'Partner',
+        'res_model': 'res.partner',
+        'view_mode': 'form',
+        'res_id': self.partner_id.id,
+        'target': 'current',
+    }
+```
+
+### Open a Filtered List
+
+```python
+def action_view_orders(self):
+    self.ensure_one()
+    return {
+        'type': 'ir.actions.act_window',
+        'name': 'Orders',
+        'res_model': 'sale.order',
+        'view_mode': 'tree,form',
+        'domain': [('partner_id', '=', self.id)],
+        'context': {'default_partner_id': self.id, 'search_default_my_orders': 1},
+    }
+```
+
+### Open via External ID
+
+```python
+def action_wizard(self):
+    action = self.env['ir.actions.actions']._for_xml_id('my_module.action_configure')
+    action['context'] = {'default_partner_id': self.id}
+    return action
+```
+
+### Close a Dialog
+
+```python
+return {'type': 'ir.actions.act_window_close'}
+```
+
+### Reload / Notify
+
+```python
+return {'type': 'ir.actions.client', 'tag': 'reload'}
+
+return {
+    'type': 'ir.actions.client',
+    'tag': 'display_notification',
+    'params': {'title': 'Saved', 'type': 'success', 'next': {'type': 'ir.actions.act_window_close'}},
+}
+```
+
+---
+
+## Quick Reference
+
+### Action Types
+
+| Type | Model | Use |
+|------|-------|-----|
+| Window | `ir.actions.act_window` | Open views for a model |
+| URL | `ir.actions.act_url` | Open a URL or controller endpoint |
+| Server | `ir.actions.server` | Run server Python / create / update / multi |
+| Report | `ir.actions.report` | QWeb PDF / HTML / Text |
+| Client | `ir.actions.client` | Registered JS action |
+| Cron | `ir.cron` | Schedule a server action |
+
+### Targets
+
+| Value | Effect |
+|-------|--------|
+| `current` | Replace main content |
+| `new` | Open in dialog |
+| `inline` | Edit inline (form only) |
+| `fullscreen` | Hide the chrome |
+| `main` | Replace main content, reset breadcrumbs |
+
+### Minimum XML for Each Type
+
+```xml
+<!-- Window -->
+<record id="a1" model="ir.actions.act_window">
+    <field name="name">Customers</field>
+    <field name="res_model">res.partner</field>
+    <field name="view_mode">tree,form</field>
+</record>
+
+<!-- URL -->
+<record id="a2" model="ir.actions.act_url">
+    <field name="name">Docs</field>
+    <field name="url">https://odoo.com</field>
+    <field name="target">new</field>
+</record>
+
+<!-- Server -->
+<record id="a3" model="ir.actions.server">
+    <field name="name">Archive</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">code</field>
+    <field name="code">records.action_archive()</field>
+</record>
+
+<!-- Report -->
+<record id="a4" model="ir.actions.report">
+    <field name="name">My Report</field>
+    <field name="model">my.model</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">my_module.tpl</field>
+</record>
+
+<!-- Client -->
+<record id="a5" model="ir.actions.client">
+    <field name="name">Dashboard</field>
+    <field name="tag">my_module.dashboard</field>
+</record>
+
+<!-- Cron -->
+<record id="a6" model="ir.cron">
+    <field name="name">Daily Sync</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="state">code</field>
+    <field name="code">model._cron_daily_sync()</field>
+    <field name="interval_number">1</field>
+    <field name="interval_type">days</field>
+    <field name="numbercall">-1</field>
+</record>
+```
+
+### Menu With Action
+
+```xml
+<menuitem id="menu_root" name="My Module" sequence="50"/>
+<menuitem id="menu_records"
+          parent="menu_root"
+          action="a1"
+          sequence="10"/>
+```
+
+---
+
+## Base Code Reference
+
+- `odoo/addons/base/models/ir_actions.py` — `IrActions`, `act_window`, `act_url`, `server`, `client`, `act_window_view`, `VIEW_TYPES`, default `view_mode='tree,form'` (v16).
+- `odoo/addons/base/models/ir_actions_report.py` — `ir.actions.report`, `report_type` selection (`qweb-pdf`, `qweb-html`, `qweb-text`), paperformat handling.
+- `odoo/addons/base/models/ir_cron.py` — `ir.cron`, `interval_type`, `numbercall`, `doall`, `nextcall`, `priority`, `_trigger()`, batching, the underlying `ir_actions_server_id` link.
+- `odoo/addons/base/models/ir_ui_menu.py` — `ir.ui.menu` model and access filtering.
+- `odoo/tools/convert.py` — data-loader shortcuts (`<menuitem>`, `<report>`, `<template>`, `<act_window>`).

--- a/skills/odoo-16.0/references/odoo-16-controller-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-controller-guide.md
@@ -1,0 +1,792 @@
+---
+name: odoo-16-controller
+description: Complete reference for Odoo 16 HTTP controllers, routing, authentication types, CSRF, CORS, and request/response handling.
+globs: "**/controllers/**/*.py"
+topics:
+  - Controller basics (class structure, request object)
+  - route decorator (URL parameters, route options, multiroute)
+  - Authentication types (user, public, none)
+  - Request/Response types (http, json)
+  - CSRF and CORS handling
+  - File uploads and downloads
+  - Common patterns (JSON endpoints, file download, website pages, API endpoints, error handling)
+when_to_use:
+  - Writing HTTP controllers
+  - Creating API endpoints
+  - Building website pages
+  - Handling webhooks and payment callbacks
+  - Implementing file uploads/downloads
+---
+
+# Odoo 16 Controller Guide
+
+Complete reference for Odoo 16 HTTP controllers, routing, and request handling.
+
+## Table of Contents
+
+1. [Controller Basics](#controller-basics)
+2. [@route Decorator](#route-decorator)
+3. [Authentication Types](#authentication-types)
+4. [Request/Response Types](#requestresponse-types)
+5. [Request Object API](#request-object-api)
+6. [CSRF Handling](#csrf-handling)
+7. [CORS Handling](#cors-handling)
+8. [File Uploads](#file-uploads)
+9. [File Downloads](#file-downloads)
+10. [Common Patterns](#common-patterns)
+11. [Best Practices](#best-practices)
+
+---
+
+## Controller Basics
+
+### Controller Class Structure
+
+```python
+from odoo import http
+from odoo.http import request
+
+
+class MyController(http.Controller):
+
+    @http.route('/my/path', type='http', auth='user')
+    def my_handler(self, **kwargs):
+        return request.render('my_module.template', {
+            'records': request.env['my.model'].search([]),
+        })
+```
+
+**Key points**:
+
+- Extend `http.Controller`.
+- Use `@http.route(...)` decorator on every public method.
+- Access `request` (the module-level proxy in `odoo.http`) for env, session, HTTP data.
+- Return the right response type for the route `type`.
+
+### Controller Inheritance / Override
+
+In Odoo 16 controllers are extended by Python inheritance (not registry-based). Any method you override MUST be re-decorated with `@http.route()`; arguments you omit are inherited from the parent.
+
+```python
+from odoo import http
+from odoo.addons.web.controllers.home import Home
+
+
+class MyHome(Home):
+
+    @http.route()  # keep path, type, auth from parent
+    def index(self, *args, **kw):
+        # custom logic
+        return super().index(*args, **kw)
+```
+
+### Module Layout
+
+```
+my_module/
+├── __init__.py
+├── __manifest__.py
+├── controllers/
+│   ├── __init__.py       # from . import main, api
+│   ├── main.py
+│   └── api.py
+└── ...
+```
+
+Remember to `from . import controllers` in the root `__init__.py`.
+
+---
+
+## @route Decorator
+
+### Basic Route
+
+```python
+from odoo import http
+
+
+class HelloController(http.Controller):
+
+    @http.route('/hello', type='http', auth='user')
+    def hello(self):
+        return "Hello World!"
+```
+
+### URL Parameters (Werkzeug Converters)
+
+```python
+from odoo.http import request
+
+# Integer path parameter
+@http.route('/order/<int:order_id>', type='http', auth='user')
+def order_view(self, order_id):
+    order = request.env['sale.order'].browse(order_id)
+    if not order.exists():
+        return request.not_found()
+    return request.render('sale.order_view', {'order': order})
+
+
+# Model converter - resolves an ID to a recordset automatically
+@http.route('/order/<model("sale.order"):order>', type='http', auth='user')
+def order_by_model(self, order):
+    return request.render('sale.order_view', {'order': order})
+
+
+# Wildcard / path parameter
+@http.route('/download/<path:file_path>', type='http', auth='user')
+def download_any(self, file_path):
+    ...
+
+
+# Query string parameters arrive as kwargs
+@http.route('/search', type='http', auth='user')
+def search_orders(self, **kwargs):
+    domain = []
+    if kwargs.get('name'):
+        domain.append(('name', 'ilike', kwargs['name']))
+    orders = request.env['sale.order'].search(domain)
+    return request.render('sale.order_list', {'orders': orders})
+```
+
+### Route Options
+
+```python
+@http.route(
+    '/my/path',                 # Route path (or list of paths)
+    type='http',                # 'http' or 'json'
+    auth='user',                # 'user' (default), 'public', 'none'
+    methods=['GET', 'POST'],    # Allowed HTTP methods (None = all)
+    csrf=True,                  # CSRF protection (default True for http, False for json)
+    cors='*',                   # Access-Control-Allow-Origin value
+    website=True,               # Defined by website module; enables website layout/context
+    sitemap=False,              # Website-only: include in sitemap
+    save_session=True,          # Persist session changes after the request
+)
+def my_handler(self):
+    ...
+```
+
+Notes on Odoo 16 specifics:
+
+- `auth` accepts exactly `'user'`, `'public'`, `'none'`. There is NO `auth='bearer'` in v16 (added in later versions). Implement token auth manually with `auth='none'` or `auth='public'` + header check (see API Endpoint pattern below).
+- `methods=None` allows every HTTP verb.
+- `csrf` default is `True` for `type='http'`, effectively ignored for `type='json'`.
+- `website=True` requires the `website` module installed.
+
+### Multiple Paths on One Handler
+
+```python
+@http.route(['/path1', '/path2'], type='http', auth='public')
+def dual(self):
+    return "Same handler for both paths"
+
+
+# Or stack decorators
+@http.route('/alpha', type='http', auth='public')
+@http.route('/beta', type='http', auth='public')
+def stacked(self):
+    return "Hello"
+```
+
+---
+
+## Authentication Types
+
+### auth='user' (Default)
+
+Requires an authenticated user. Unauthenticated requests are redirected to the login page.
+
+```python
+@http.route('/my/orders', type='http', auth='user')
+def my_orders(self):
+    orders = request.env['sale.order'].search([
+        ('user_id', '=', request.env.user.id),
+    ])
+    return request.render('my_module.orders', {'orders': orders})
+```
+
+Behavior:
+
+- `request.env.user` is the logged-in user.
+- `request.env.uid` is that user's id.
+- Normal ACL / record rules apply.
+
+### auth='public'
+
+Allows unauthenticated access, using the shared "Public user" record.
+
+```python
+@http.route('/shop/products', type='http', auth='public')
+def shop_products(self):
+    products = request.env['product.product'].search([
+        ('website_published', '=', True),
+    ])
+    return request.render('my_module.shop', {'products': products})
+```
+
+Behavior:
+
+- If the visitor is logged in, runs as that user.
+- If not, runs as the public user (usually limited access).
+- ACL / record rules still apply; use `.sudo()` only when truly needed.
+
+### auth='none'
+
+No environment, no database authentication at all.
+
+```python
+@http.route('/healthz', type='http', auth='none', csrf=False)
+def healthcheck(self):
+    return "OK"
+```
+
+Behavior:
+
+- `request.env` is NOT available.
+- Route works even when no database is selected.
+- Use for static endpoints, health checks, some login screens, or manual token verification against external services.
+
+### Odoo 16 does NOT have `auth='bearer'`
+
+`auth='bearer'` was introduced in later Odoo versions. In 16, implement your own bearer-token logic:
+
+```python
+from odoo import http
+from odoo.http import request
+from werkzeug.exceptions import Unauthorized
+
+
+class ApiAuth(http.Controller):
+
+    @http.route('/api/v1/me', type='json', auth='none', csrf=False)
+    def api_me(self, **params):
+        token = request.httprequest.headers.get('Authorization', '')
+        if not token.startswith('Bearer '):
+            raise Unauthorized()
+        token = token[7:]
+        # Resolve token -> user (custom model), then manually set up env
+        user = request.env(su=True)['api.token']._authenticate(token)
+        if not user:
+            raise Unauthorized()
+        request.update_env(user=user.id)
+        return {'login': user.login, 'name': user.name}
+```
+
+---
+
+## Request/Response Types
+
+### type='http' - HTML / Text / Binary
+
+The handler's return value can be:
+
+- A `str` or `bytes` (taken as the body).
+- An `odoo.http.Response` created with `request.make_response` / `request.render` / `request.redirect` / `request.not_found`.
+- A Werkzeug response object.
+
+```python
+from odoo.http import request
+
+
+# Render a QWeb template
+@http.route('/page', type='http', auth='user')
+def my_page(self):
+    return request.render('my_module.template', {
+        'records': request.env['my.model'].search([]),
+    })
+
+
+# Plain text
+@http.route('/ping', type='http', auth='none')
+def ping(self):
+    return "PONG"
+
+
+# Response with headers
+@http.route('/inline_pdf/<int:doc_id>', type='http', auth='user')
+def inline_pdf(self, doc_id):
+    report = request.env.ref('my_module.action_report')
+    pdf, _ = report._render_qweb_pdf(report.report_name, [doc_id])
+    return request.make_response(pdf, headers=[
+        ('Content-Type', 'application/pdf'),
+        ('Content-Length', len(pdf)),
+    ])
+
+
+# Redirect (local or absolute)
+@http.route('/go', type='http', auth='user')
+def go(self):
+    return request.redirect('/web')
+
+
+# 404
+@http.route('/maybe/<int:rec_id>', type='http', auth='user')
+def maybe(self, rec_id):
+    rec = request.env['my.model'].browse(rec_id).exists()
+    if not rec:
+        return request.not_found()
+    return request.render('my_module.detail', {'rec': rec})
+```
+
+### type='json' - JSON-RPC 2.0
+
+In Odoo 16, `type='json'` expects a JSON-RPC 2.0 envelope in the POST body:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "call",
+    "params": {"id": 42, "limit": 10},
+    "id": 1
+}
+```
+
+The endpoint receives the dict under `"params"` as keyword arguments; the return value is serialized as the `"result"` field of the response.
+
+```python
+@http.route('/api/records', type='json', auth='user')
+def get_records(self, domain=None, limit=80, offset=0):
+    domain = domain or []
+    records = request.env['my.model'].search_read(
+        domain, ['id', 'name', 'state'],
+        limit=limit, offset=offset,
+    )
+    return {'records': records, 'count': len(records)}
+```
+
+Calling from OWL:
+
+```javascript
+// Using the rpc service (Odoo 16 pattern)
+this.rpc = useService("rpc");
+const res = await this.rpc("/api/records", { domain: [["state", "=", "open"]], limit: 20 });
+```
+
+`type='json'` behavior:
+
+- CSRF is disabled by default (the JSON-RPC client handles the exchange).
+- Exceptions raised in the handler are serialized as JSON-RPC errors.
+- Python `UserError` / `AccessError` surface to the browser as user-friendly dialogs.
+
+---
+
+## Request Object API
+
+`from odoo.http import request`
+
+### Environment
+
+```python
+request.env            # odoo.api.Environment bound to the authenticated user
+request.env.user       # res.users recordset (the current user)
+request.env.company    # Current company (res.company)
+request.env.companies  # Allowed companies (res.company recordset)
+request.env.lang       # Language code of the user's context
+request.env.uid        # Integer user id
+request.env.context    # Context dict (lang, tz, allowed_company_ids, ...)
+```
+
+You can `.sudo()` the env like in any ORM context:
+
+```python
+partner = request.env['res.partner'].sudo().browse(partner_id)
+```
+
+### Session
+
+```python
+request.session              # dict-like Session object
+request.session.uid          # Logged-in user id (or None)
+request.session.db           # Current database name
+request.session['cart_id']   # Custom session entries (must be JSON-serialisable)
+request.session.get('foo')   # Safe read
+```
+
+### HTTP Data
+
+```python
+request.httprequest            # Underlying werkzeug.wrappers.Request
+request.httprequest.method     # 'GET', 'POST', ...
+request.httprequest.headers    # werkzeug Headers
+request.httprequest.files      # FileStorage dict (multipart uploads)
+request.httprequest.remote_addr
+request.params                 # Merged query string + form body + JSON params
+request.db                     # Current db name or None
+request.csrf_token()           # Fresh CSRF token (use in forms)
+```
+
+### Response Helpers
+
+```python
+request.render(template, values=None, **kw)       # Lazy QWeb rendering
+request.make_response(body, headers=None, cookies=None, status=200)
+request.make_json_response(data, headers=None, cookies=None, status=200)
+request.not_found(description=None)
+request.redirect(location, code=303, local=True)
+request.redirect_query(location, query=None, code=303, local=True)
+```
+
+---
+
+## CSRF Handling
+
+### Default Behavior
+
+- `type='http'` POST/PUT/DELETE require a CSRF token (`csrf_token` form field).
+- GET/HEAD/OPTIONS never require CSRF.
+- `type='json'` doesn't check CSRF (JSON-RPC clients handle the exchange themselves).
+
+### Form with CSRF Token
+
+```xml
+<form action="/my/form/submit" method="POST">
+    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+    <input type="text" name="email"/>
+    <button type="submit">Send</button>
+</form>
+```
+
+```python
+@http.route('/my/form/submit', type='http', auth='public', methods=['POST'])
+def form_submit(self, email=None, **kw):
+    # csrf_token already validated by the framework
+    request.env['newsletter.signup'].sudo().create({'email': email})
+    return request.redirect('/thanks')
+```
+
+### Disabling CSRF (Webhooks / Server-to-Server)
+
+Only disable CSRF for endpoints you protect another way (HMAC signature, IP whitelist, bearer token):
+
+```python
+@http.route('/webhook/payment', type='http', auth='none', methods=['POST'], csrf=False)
+def payment_webhook(self, **kwargs):
+    signature = request.httprequest.headers.get('X-Hub-Signature')
+    # Verify HMAC here
+    ...
+    return "OK"
+```
+
+---
+
+## CORS Handling
+
+Set the `cors` option on the route. Odoo 16 emits `Access-Control-Allow-Origin` and automatically serves preflight OPTIONS with compatible headers.
+
+```python
+@http.route('/api/v1/status', type='json', auth='none', cors='*', csrf=False)
+def api_status(self):
+    return {'status': 'ok'}
+
+
+# Restrict to a specific origin
+@http.route('/api/v1/orders', type='json', auth='user', cors='https://partner.example.com')
+def api_orders(self, **kw):
+    ...
+```
+
+For public APIs, combine `cors='*'` with `csrf=False` (since browsers can't send CSRF tokens cross-origin). Prefer `type='json'` so the framework handles preflight correctly.
+
+---
+
+## File Uploads
+
+Multipart file uploads arrive in `request.httprequest.files`. Each entry is a `werkzeug.datastructures.FileStorage`.
+
+```python
+import base64
+
+from odoo import http
+from odoo.http import request
+
+
+class UploadController(http.Controller):
+
+    @http.route('/my/upload', type='http', auth='user', methods=['POST'])
+    def upload(self, **post):
+        upload = request.httprequest.files.get('file')
+        if not upload:
+            return request.make_response("No file", status=400)
+
+        data = upload.read()  # bytes
+        attachment = request.env['ir.attachment'].create({
+            'name': upload.filename,
+            'datas': base64.b64encode(data),
+            'mimetype': upload.mimetype,
+            'res_model': 'my.model',
+            'res_id': int(post.get('res_id', 0)) or False,
+        })
+        return request.redirect(f'/web#id={attachment.res_id}&model=my.model')
+```
+
+HTML form:
+
+```xml
+<form action="/my/upload" method="POST" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+    <input type="hidden" name="res_id" t-att-value="rec.id"/>
+    <input type="file" name="file"/>
+    <button type="submit">Upload</button>
+</form>
+```
+
+For large uploads, stream with `upload.stream` instead of `upload.read()`.
+
+---
+
+## File Downloads
+
+### Option 1: `request.make_response` (small payloads)
+
+```python
+@http.route('/download/report/<int:report_id>', type='http', auth='user')
+def download_report(self, report_id):
+    report = request.env['ir.actions.report'].browse(report_id)
+    pdf, _ = report._render_qweb_pdf(report.report_name, [report_id])
+    return request.make_response(pdf, headers=[
+        ('Content-Type', 'application/pdf'),
+        ('Content-Disposition', f'attachment; filename="{report.name}.pdf"'),
+        ('Content-Length', len(pdf)),
+    ])
+```
+
+### Option 2: `http.Stream` (Odoo 16 preferred helper)
+
+`odoo.http.Stream` is the recommended way to serve files or binary fields with proper caching, ETag, and conditional support.
+
+```python
+from odoo import http
+from odoo.http import Stream, request
+
+
+class DownloadController(http.Controller):
+
+    @http.route('/download/attachment/<int:attachment_id>', type='http', auth='user')
+    def download_attachment(self, attachment_id):
+        attachment = request.env['ir.attachment'].browse(attachment_id).exists()
+        if not attachment:
+            return request.not_found()
+        attachment.check('read')  # ACL
+        return Stream.from_attachment(attachment).get_response(as_attachment=True)
+
+    @http.route('/download/field/<int:rec_id>', type='http', auth='user')
+    def download_binary_field(self, rec_id):
+        rec = request.env['my.model'].browse(rec_id).exists()
+        if not rec:
+            return request.not_found()
+        return Stream.from_binary_field(rec, 'binary_field').get_response(
+            as_attachment=True,
+        )
+```
+
+`Stream` constructors in v16:
+
+- `Stream.from_path(path, filter_ext=('',), public=False)` — serve a file on disk.
+- `Stream.from_attachment(attachment)` — from an `ir.attachment` record.
+- `Stream.from_binary_field(record, field_name)` — from a binary/image field.
+
+---
+
+## Common Patterns
+
+### JSON Endpoint for Frontend
+
+```python
+from odoo import http
+from odoo.http import request
+
+
+class MyWebController(http.Controller):
+
+    @http.route('/my/data', type='json', auth='user')
+    def get_data(self, domain=None, fields=None):
+        domain = domain or []
+        fields = fields or ['id', 'name', 'date']
+        records = request.env['my.model'].search_read(domain, fields)
+        return {'records': records, 'count': len(records)}
+
+    @http.route('/my/action', type='json', auth='user')
+    def do_action(self, record_id, action_type):
+        record = request.env['my.model'].browse(record_id).exists()
+        if not record:
+            return {'error': 'Record not found'}
+        if action_type == 'validate':
+            record.action_validate()
+        elif action_type == 'cancel':
+            record.action_cancel()
+        return {'success': True, 'state': record.state}
+```
+
+OWL side:
+
+```javascript
+/** @odoo-module **/
+import { useService } from "@web/core/utils/hooks";
+
+setup() {
+    this.rpc = useService("rpc");
+}
+
+async loadData() {
+    const res = await this.rpc("/my/data", { domain: [["state", "=", "open"]] });
+    this.state.records = res.records;
+}
+```
+
+### Website Page
+
+```python
+from odoo import http
+from odoo.http import request
+
+
+class WebsiteCatalog(http.Controller):
+
+    @http.route('/shop', type='http', auth='public', website=True, sitemap=True)
+    def shop(self, **kw):
+        products = request.env['product.template'].search([
+            ('website_published', '=', True),
+            ('sale_ok', '=', True),
+        ])
+        return request.render('my_module.shop', {
+            'products': products,
+        })
+
+    @http.route('/shop/<model("product.template"):product>',
+                type='http', auth='public', website=True)
+    def product(self, product, **kw):
+        return request.render('my_module.product', {
+            'product': product,
+        })
+```
+
+### External API Endpoint (Token-Protected)
+
+```python
+from odoo import http
+from odoo.http import request
+from werkzeug.exceptions import Forbidden
+
+
+class SalesApi(http.Controller):
+
+    def _check_api_key(self):
+        key = request.httprequest.headers.get('X-Api-Key')
+        expected = request.env['ir.config_parameter'].sudo().get_param('my_module.api_key')
+        if not key or key != expected:
+            raise Forbidden()
+
+    @http.route('/api/v1/orders', type='json', auth='user', csrf=False, cors='*')
+    def list_orders(self, domain=None, limit=80):
+        self._check_api_key()
+        orders = request.env['sale.order'].sudo().search_read(
+            domain or [],
+            ['id', 'name', 'state', 'amount_total', 'partner_id'],
+            limit=limit,
+        )
+        return {'orders': orders}
+
+    @http.route('/api/v1/orders/<int:order_id>', type='json', auth='user', csrf=False, cors='*')
+    def get_order(self, order_id):
+        self._check_api_key()
+        order = request.env['sale.order'].sudo().browse(order_id).exists()
+        if not order:
+            return {'error': 'not_found'}
+        return order.read(['name', 'state', 'amount_total'])[0]
+```
+
+### Webhook (No CSRF, HMAC-Verified)
+
+```python
+import hmac
+import hashlib
+
+from odoo import http
+from odoo.http import request
+
+
+class StripeWebhook(http.Controller):
+
+    @http.route('/webhook/stripe', type='http', auth='none',
+                methods=['POST'], csrf=False)
+    def stripe_webhook(self, **kwargs):
+        secret = request.env(su=True)['ir.config_parameter'].get_param('stripe.webhook_secret')
+        signature = request.httprequest.headers.get('Stripe-Signature', '')
+        payload = request.httprequest.get_data()
+        expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, signature):
+            return request.make_response("bad signature", status=400)
+        # Process event
+        ...
+        return "OK"
+```
+
+### Error Handling
+
+```python
+from odoo import http
+from odoo.http import request
+from odoo.exceptions import UserError, AccessError
+
+
+class ActionController(http.Controller):
+
+    @http.route('/action', type='json', auth='user')
+    def do_action(self, record_id):
+        try:
+            record = request.env['my.model'].browse(record_id)
+            record.action_validate()
+            return {'success': True}
+        except AccessError as e:
+            return {'error': 'access_denied', 'message': str(e)}
+        except UserError as e:
+            return {'error': 'user_error', 'message': str(e)}
+
+    @http.route('/page', type='http', auth='user')
+    def my_page(self):
+        try:
+            return request.render('my_module.template', {
+                'data': self._get_data(),
+            })
+        except UserError as e:
+            return request.render('my_module.error', {'message': str(e)})
+        except Exception:
+            return request.not_found()
+```
+
+### Response Methods Quick Reference
+
+```python
+request.render('module.template', values)                     # Lazy QWeb render
+request.make_response(body, headers=[...], status=200)        # Raw body + headers
+request.make_json_response({'key': 'value'}, status=200)      # JSON body
+request.redirect('/somewhere')                                # 303 redirect (local)
+request.redirect('https://other.example', local=False)        # Absolute redirect
+request.not_found()                                           # 404
+```
+
+---
+
+## Best Practices
+
+1. **Keep controllers thin.** Move business logic into models. Controllers handle HTTP concerns only.
+2. **Pick the right `type`.** `'http'` for pages, forms, downloads; `'json'` for frontend RPC calls and machine APIs.
+3. **Default to `auth='user'`.** Use `'public'` only for unauthenticated features; `'none'` only when you must bypass the ORM entirely.
+4. **Don't `sudo()` by reflex.** Prefer proper ACLs / record rules; `sudo()` is for deliberate privilege elevation.
+5. **Validate inputs.** `int(kwargs.get('id', 0))`, enum whitelists, length checks — the browser is untrusted.
+6. **Check existence.** `rec.exists()` before operating on browsed ids.
+7. **Respect CSRF.** Only disable it when you authenticate the request another way (HMAC, API key, bearer token).
+8. **Set `cors` explicitly for JSON APIs** used cross-origin, and pair with `csrf=False`.
+9. **Use `Stream` for downloads.** Proper caching, ETag, conditional GET come for free.
+10. **Raise werkzeug exceptions for HTTP errors** (`NotFound`, `Forbidden`, `BadRequest`) rather than returning ad-hoc strings.
+
+---
+
+## Base Code Reference
+
+The APIs documented here are defined in the Odoo 16 source:
+
+- `odoo/http.py` — `Controller`, `route`, `Request`, `Response`, `Stream`, session, dispatching.
+- `odoo/exceptions.py` — `UserError`, `AccessError`, `ValidationError`.
+- `addons/web/controllers/report.py` — reference controllers, e.g. `/report/barcode`, `/report/download`.
+- `addons/web/controllers/home.py` — base web client routes (useful for inheritance examples).

--- a/skills/odoo-16.0/references/odoo-16-data-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-data-guide.md
@@ -1,0 +1,724 @@
+---
+name: odoo-16-data
+description: Complete reference for Odoo 16 data files - XML and CSV. Covers record/field/delete/function tags, shortcuts (menuitem, template, asset), noupdate, and value resolution (eval/ref/search/obj/file/type).
+globs: "**/*.{xml,csv}"
+topics:
+  - XML data files structure (<odoo>, <data>)
+  - record tag (create / update records)
+  - field tag value resolution (eval, ref, search, obj, file, type)
+  - delete tag
+  - function tag (calling methods / module hooks)
+  - Shortcuts (menuitem, template, asset)
+  - CSV data files and :id suffix references
+  - noupdate attribute
+  - External IDs and module prefixes
+when_to_use:
+  - Authoring v16 data / demo files
+  - Loading views, menus, actions, security rules
+  - Populating seed data on install
+  - Referencing other modules' records
+---
+
+# Odoo 16 Data Files Guide
+
+Reference for Odoo 16 data files: XML structure, record/field/delete/function tags, shortcuts, CSV files, and value resolution.
+
+## Table of Contents
+
+1. [Data File Structure](#data-file-structure)
+2. [External IDs](#external-ids)
+3. [`<record>` Tag](#record-tag)
+4. [`<field>` Tag Values (eval / ref / search / obj / type / file)](#field-tag-values)
+5. [Relational Field Commands](#relational-field-commands)
+6. [`<delete>` Tag](#delete-tag)
+7. [`<function>` Tag](#function-tag)
+8. [Shortcuts (`<menuitem>`, `<template>`, `<report>`, `<act_window>`)](#shortcuts)
+9. [CSV Data Files](#csv-data-files)
+10. [`noupdate` Attribute](#noupdate-attribute)
+11. [Loading Order & Modes](#loading-order--modes)
+12. [Quick Reference](#quick-reference)
+
+---
+
+## Data File Structure
+
+Every XML data file is a well-formed XML document whose root is `<odoo>`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- (Re-)loaded at install and at every module upgrade -->
+    <record id="always_updatable" model="my.model">
+        <field name="name">Value</field>
+    </record>
+
+    <!-- Loaded on install; skipped on upgrade -->
+    <data noupdate="1">
+        <record id="user_editable" model="my.model">
+            <field name="name">Default</field>
+        </record>
+    </data>
+</odoo>
+```
+
+### Accepted Top-Level Tags
+
+The loader (`odoo/tools/convert.py`) recognises these children of `<odoo>` / `<data>`:
+
+| Tag | Purpose |
+|-----|---------|
+| `<record>` | Create or update a record of an arbitrary model |
+| `<delete>` | Delete records by id or by search domain |
+| `<function>` | Call an arbitrary model method |
+| `<menuitem>` | Shortcut to create an `ir.ui.menu` |
+| `<template>` | Shortcut to create a QWeb `ir.ui.view` |
+| `<report>` | Shortcut to create an `ir.actions.report` |
+| `<act_window>` | Shortcut to create an `ir.actions.act_window` (legacy) |
+Any other tag at the top level is silently ignored by the loader.
+
+### File Locations
+
+Convention-based, declared via the `data:` / `demo:` keys of `__manifest__.py`:
+
+| Directory | When Loaded |
+|-----------|-------------|
+| `data/` | Always, at install and upgrade |
+| `demo/` | Only when `--without-demo` is not set |
+| `security/` | Typically contains `ir.model.access.csv` and record-rule XML (loaded from `data:` in the manifest) |
+| `views/` | Views/menus/actions (loaded from `data:`) |
+
+---
+
+## External IDs
+
+Every data record is addressed by an **external ID** (aka XML-id), stored in `ir.model.data`.
+
+Format: `module.name`
+
+- Inside the same module, `module.` can be omitted: `<field name="user_id" ref="admin"/>` is equivalent to `ref="<current_module>.admin"`.
+- Across modules always use the full form: `ref="base.user_admin"`.
+- Only **one dot** is allowed: `module.identifier` (the identifier itself must not contain a dot).
+
+```xml
+<record id="my_partner" model="res.partner">
+    <field name="name">Corp</field>
+</record>
+
+<record id="my_contact" model="res.partner">
+    <field name="name">Jane</field>
+    <field name="parent_id" ref="my_partner"/>            <!-- same module -->
+    <field name="country_id" ref="base.us"/>              <!-- cross module -->
+</record>
+```
+
+---
+
+## `<record>` Tag
+
+```xml
+<record id="partner_acme" model="res.partner">
+    <field name="name">ACME Corp</field>
+    <field name="is_company" eval="True"/>
+    <field name="country_id" ref="base.us"/>
+</record>
+```
+
+### `<record>` Attributes
+
+| Attribute | Purpose |
+|-----------|---------|
+| `id` | External ID (recommended, required to make the record updatable) |
+| `model` | Target model (required) |
+| `context` | Extra context dict passed to create/write (rarely needed) |
+| `forcecreate` | If `"0"`/`"false"` and the record does not exist during an **update** run inside a `noupdate="1"` block, skip creation instead of raising |
+
+### Create vs. Update
+
+The loader decides based on the existence of the external ID:
+
+- First time the file is loaded → `create`.
+- Subsequent upgrades → `write` (unless the data is protected by `noupdate="1"`).
+
+If you re-declare only a subset of the fields, only those fields are written:
+
+```xml
+<!-- Later XML (same id) only updates `email` -->
+<record id="partner_acme" model="res.partner">
+    <field name="email">info@acme.test</field>
+</record>
+```
+
+An empty `<record>` (no `<field>` children) produces no write.
+
+---
+
+## `<field>` Tag Values
+
+A `<field>` sets one attribute of the record. Its value is resolved in the following priority:
+
+1. `search="..."` — evaluate a domain, use the first match (or all matches for many2many).
+2. `ref="..."` — resolve an external ID.
+3. `eval="..."` — evaluate a Python expression.
+4. Inline text (interpreted based on `type="..."`, default `char`).
+
+### Empty Field = `False`
+
+```xml
+<field name="partner_id"/>   <!-- Sets to False -->
+```
+
+### Direct Value
+
+```xml
+<field name="name">ACME Corp</field>
+<field name="ref">ACME-001</field>
+```
+
+Leading / trailing whitespace is preserved. Numeric/boolean coercion is driven by the destination field's ORM type (so `<field name="active">1</field>` writes `True` on a Boolean).
+
+### `type="..."` — Interpretation Hints
+
+| Type | Semantics |
+|------|-----------|
+| `char` (default) | Plain string |
+| `int` | Integer (`None` maps to Python `None`) |
+| `float` | Float |
+| `xml` / `html` | Serialise child XML/HTML into the field (wraps multiple roots in a `<data>` container) |
+| `file` | Stored as `"module,/path"` - validated against `addons_path` |
+| `base64` | Base64-encode the bytes read from `file=` |
+| `list` / `tuple` | Build a list/tuple from nested `<value>` children |
+
+```xml
+<!-- HTML body -->
+<field name="description" type="html">
+    <p>Read the <a href="https://odoo.com">docs</a>.</p>
+</field>
+
+<!-- Binary file loaded from a module path -->
+<field name="data" type="base64" file="my_module/static/src/img/logo.png"/>
+
+<!-- File path reference -->
+<field name="image_path" type="file" name="my_module/static/src/img/photo.jpg"/>
+
+<!-- Integer -->
+<field name="priority" type="int">10</field>
+
+<!-- List -->
+<field name="tags" type="list">
+    <value>alpha</value>
+    <value>beta</value>
+    <value eval="'gamma'"/>
+</field>
+```
+
+### `eval="..."` — Python Expression
+
+Evaluated with `safe_eval`. The evaluation context (see `convert.py::_get_idref`) includes:
+
+| Name | Description |
+|------|-------------|
+| `True`, `False`, `None` | Python literals |
+| `ref` | `ref('module.xmlid')` → database integer id |
+| `obj` | `obj('res.partner')` → browse by model name (resolves to `env['res.partner'].browse`) |
+| `Command` | `odoo.fields.Command` helpers (`Command.link`, `Command.set`, ...) |
+| `time`, `datetime`, `DateTime`, `timedelta`, `relativedelta` | Date/time helpers |
+| `pytz` | Timezone helper |
+| `version` | Odoo major version string (e.g. `"16.0"`) |
+
+```xml
+<field name="active" eval="True"/>
+<field name="amount" eval="19.95"/>
+<field name="date"   eval="(datetime.date.today() + relativedelta(days=30)).strftime('%Y-%m-%d')"/>
+<field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
+<field name="tag_ids"   eval="[Command.set([ref('tag_a'), ref('tag_b')])]"/>
+```
+
+### `ref="..."` — External ID Reference
+
+Resolves an external ID to its database integer id. Works on Many2one and on any field expecting an id.
+
+```xml
+<field name="user_id" ref="base.user_admin"/>
+<field name="country_id" ref="base.us"/>
+```
+
+On a **reference** (polymorphic) field, `ref` sets `"model,id"` automatically:
+
+```xml
+<field name="resource_ref" ref="base.user_admin"/>
+<!-- Stored as "res.users,<id>" -->
+```
+
+### `search="..."` — Domain Search
+
+Evaluate an ORM domain, take the result.
+
+```xml
+<record id="demo_partner" model="res.partner">
+    <field name="name">Demo</field>
+    <field name="country_id" search="[('code','=','US')]"/>   <!-- first match -->
+    <field name="category_id" search="[('name','in',['VIP','Gold'])]"/>
+    <!-- For Many2many: all matched ids become the linked set -->
+</record>
+```
+
+Rules:
+
+- Many2one: uses the first matching record.
+- Many2many: uses the full set, written via `Command.set`.
+- Use `use="..."` to pick a field other than `id`.
+
+### `obj` — Browse Records in `eval`
+
+Inside `eval`, `obj('model.name')` returns a recordset proxy. Useful for computed defaults:
+
+```xml
+<record id="seq_my_model" model="ir.sequence">
+    <field name="name">My sequence</field>
+    <field name="prefix">MM-</field>
+    <field name="padding" eval="obj('res.company').search([], limit=1).id or 4"/>
+</record>
+```
+
+### Inline File Content
+
+```xml
+<!-- File path stored as "module,path" (for fields that expect a relative path) -->
+<field name="image_path" type="file" name="my_module/static/src/img/photo.png"/>
+
+<!-- File content base64-encoded (for Binary fields) -->
+<field name="icon" type="base64" file="my_module/static/description/icon.png"/>
+```
+
+---
+
+## Relational Field Commands
+
+Odoo 16 uses `odoo.Command` (exposed in `eval` as `Command`) or the legacy tuple form.
+
+| Command | Tuple form | Effect |
+|---------|------------|--------|
+| `Command.create(values)` | `(0, 0, {values})` | Create a related record |
+| `Command.update(id, values)` | `(1, id, {values})` | Update the linked record |
+| `Command.delete(id)` | `(2, id, 0)` | Delete the record and unlink |
+| `Command.unlink(id)` | `(3, id, 0)` | Unlink only |
+| `Command.link(id)` | `(4, id, 0)` | Link (for M2M/O2M) |
+| `Command.clear()` | `(5, 0, 0)` | Clear all links |
+| `Command.set([ids])` | `(6, 0, [ids])` | Replace the link set |
+
+Examples:
+
+```xml
+<!-- Replace tags (M2M) -->
+<field name="category_id" eval="[Command.set([ref('cat_customer'), ref('cat_supplier')])]"/>
+
+<!-- Add a tag without removing existing -->
+<field name="category_id" eval="[Command.link(ref('cat_vip'))]"/>
+
+<!-- Clear -->
+<field name="line_ids" eval="[Command.clear()]"/>
+
+<!-- Create inline child (O2M) -->
+<field name="line_ids" eval="[
+    Command.create({'name': 'Line A', 'price': 10.0}),
+    Command.create({'name': 'Line B', 'price': 20.0}),
+]"/>
+```
+
+Legacy tuples still work everywhere:
+
+```xml
+<field name="groups_id" eval="[(6, 0, [ref('base.group_user')])]"/>
+```
+
+### Inline O2M via Nested `<record>`
+
+A nicer way to create children with their own external IDs:
+
+```xml
+<record id="order_demo" model="sale.order">
+    <field name="partner_id" ref="base.res_partner_2"/>
+
+    <record id="order_demo_line_1" model="sale.order.line">
+        <field name="product_id" ref="product.product_product_1"/>
+        <field name="product_uom_qty">1</field>
+    </record>
+    <record id="order_demo_line_2" model="sale.order.line">
+        <field name="product_id" ref="product.product_product_2"/>
+        <field name="product_uom_qty">2</field>
+    </record>
+</record>
+```
+
+The loader writes the parent first, then inserts each nested record with the right `inverse_name` set to the parent's id.
+
+---
+
+## `<delete>` Tag
+
+Remove records at load time.
+
+```xml
+<!-- By external ID -->
+<delete model="res.partner" id="legacy.partner_old"/>
+
+<!-- By domain (removes all matching) -->
+<delete model="ir.ui.menu" search="[('name','=','Obsolete')]"/>
+```
+
+`id` and `search` are mutually exclusive. If `id` does not exist the loader logs a warning and continues.
+
+---
+
+## `<function>` Tag
+
+Invoke a method on a model.
+
+```xml
+<!-- With eval -> positional args list -->
+<function model="res.partner" name="create"
+          eval="[{'name': 'From XML', 'email': 'x@example.com'}]"/>
+
+<!-- With explicit <value> children -->
+<function model="my.module" name="setup_defaults">
+    <value>arg1</value>
+    <value eval="ref('base.user_admin')"/>
+    <value name="company_id" eval="ref('base.main_company')"/>   <!-- becomes kwarg -->
+</function>
+
+<!-- Nested function: the inner call's result is passed as args -->
+<function model="res.partner" name="write">
+    <function model="res.partner" name="search"
+              eval="[[('vip','=',True)]]"/>
+    <value eval="{'category_id': [Command.link(ref('cat_vip'))]}"/>
+</function>
+```
+
+Note: inside a `<data noupdate="1">` block, `<function>` is **skipped** except during an `init` install (`convert.py::_tag_function`). Use it for post-install hooks, cache clearing, or one-shot migrations.
+
+---
+
+## Shortcuts
+
+### `<menuitem>` — ir.ui.menu Shortcut
+
+```xml
+<menuitem id="menu_root" name="My Module" sequence="10" web_icon="my_module,static/description/icon.png"/>
+
+<menuitem id="menu_records"
+          name="Records"
+          parent="menu_root"
+          action="action_my_records"
+          sequence="1"/>
+
+<!-- Nested (auto-creates intermediate from id of another menuitem) -->
+<menuitem id="menu_reporting" parent="menu_root" name="Reporting"/>
+<menuitem id="menu_report_analysis"
+          parent="menu_reporting"
+          action="action_report_analysis"/>
+
+<!-- Security groups (prefix "-" to remove) -->
+<menuitem id="menu_admin_only"
+          name="Administration"
+          parent="menu_root"
+          groups="base.group_system"/>
+
+<menuitem id="menu_regular_users"
+          name="Users"
+          parent="menu_root"
+          groups="base.group_user,-base.group_portal"/>
+
+<!-- Nested via XML nesting (rarely used; equivalent to parent=) -->
+<menuitem id="menu_outer" name="Outer">
+    <menuitem id="menu_inner" name="Inner" action="action_x"/>
+</menuitem>
+```
+
+| Attribute | Description |
+|-----------|-------------|
+| `id` | External ID (required) |
+| `name` | Label (defaults to `id` if omitted) |
+| `parent` | Parent menu external ID |
+| `action` | External ID of any `ir.actions.*` record |
+| `sequence` | Integer; lower sorts first |
+| `groups` | Comma-separated groups; prefix `-` to exclude |
+| `web_icon` | `module,path/to/icon.png` — used for top-level app menus |
+| `active` | `"True"` / `"False"` |
+
+### `<template>` — QWeb ir.ui.view Shortcut
+
+```xml
+<template id="landing_page" name="Landing Page">
+    <div class="container">
+        <h1 t-out="title"/>
+    </div>
+</template>
+
+<!-- Inheritance -->
+<template id="landing_page_extra" inherit_id="my_module.landing_page">
+    <xpath expr="//h1" position="after">
+        <p>Extended</p>
+    </xpath>
+</template>
+
+<!-- Primary (a clone rather than a modifier) -->
+<template id="landing_alternative"
+          inherit_id="my_module.landing_page"
+          primary="True"/>
+
+<!-- Groups, active, priority -->
+<template id="admin_only" groups="base.group_system" priority="20" active="True">
+    ...
+</template>
+```
+
+The shortcut expands to an `ir.ui.view` record with `type="qweb"` and `arch` set to the inner XML.
+
+### `ir.asset` records in XML
+
+```xml
+<record id="my_module_backend_asset" model="ir.asset">
+    <field name="name">My Module Backend Assets</field>
+    <field name="bundle">web.assets_backend</field>
+    <field name="path">my_module/static/src/js/my_component.js</field>
+</record>
+```
+
+Odoo 16 does not provide a top-level `<asset>` loader shortcut. When you need
+XML-managed assets, declare `ir.asset` rows with normal `<record>` tags. For
+most module assets, prefer the `'assets'` key in `__manifest__.py`.
+
+### `<report>` Shortcut (Actions)
+
+```xml
+<report
+    id="action_report_my_model"
+    string="My Report"
+    model="my.model"
+    report_type="qweb-pdf"
+    name="my_module.my_report_template"
+    file="my_module.my_report"
+    attachment_use="True"
+    attachment="'Report-' + (object.name or '').replace('/', '_') + '.pdf'"
+    print_report_name="'Report-%s' % (object.name)"/>
+```
+
+This expands to an `ir.actions.report` record.
+
+---
+
+## CSV Data Files
+
+CSV files are the go-to format for flat, bulk data (access rights, translations, country lookups, etc.).
+
+### Naming
+
+The file name is `<model_with_dots_as_underscores>.csv`:
+
+| Model | File |
+|-------|------|
+| `ir.model.access` | `ir.model.access.csv` |
+| `res.country.state` | `res.country.state.csv` |
+
+### Structure
+
+- Header row: field names. `id` references the external id.
+- Each subsequent row is one record.
+- Use `:id` suffix on a column to look up related records by their external id.
+
+```csv
+id,country_id:id,name,code
+state_us_ca,base.us,California,CA
+state_us_ny,base.us,New York,NY
+```
+
+### Typical Use Cases
+
+#### `ir.model.access.csv`
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,my_module.model_my_model,base.group_user,1,0,0,0
+access_my_model_manager,my.model.manager,my_module.model_my_model,my_module.group_manager,1,1,1,1
+```
+
+#### Simple Master Data
+
+```csv
+id,name,code,active
+tag_vip,VIP,VIP,True
+tag_new,New Customer,NEW,True
+```
+
+### CSV vs XML
+
+| CSV | XML |
+|-----|-----|
+| Simpler for bulk seed data | Supports all features (eval, search, type, relational commands) |
+| No Python evaluation | Required for HTML blocks, complex relationships |
+| Only `:id` reference shorthand | Full external-id + domain search |
+| Single model per file | Multiple models per file |
+
+---
+
+## `noupdate` Attribute
+
+`noupdate` controls whether records in a block are refreshed on `-u` (module update).
+
+```xml
+<odoo>
+    <!-- Always refreshed on upgrade -->
+    <record id="view_x_form" model="ir.ui.view">
+        <field name="model">x</field>
+        <field name="arch" type="xml">...</field>
+    </record>
+
+    <!-- Only inserted once (install), never overwritten -->
+    <data noupdate="1">
+        <record id="default_company_website" model="res.company">
+            <field name="website">https://example.com</field>
+        </record>
+    </data>
+</odoo>
+```
+
+### `noupdate` On the Record Itself
+
+You can also set `noupdate` on a single record's `ir.model.data`:
+
+```xml
+<record id="my_partner" model="res.partner">
+    <field name="name">Partner</field>
+</record>
+<!-- Then protect it in a second pass -->
+<function model="ir.model.data" name="write" eval="[
+    [ref('__ir_model_data_id_of_my_partner__')],
+    {'noupdate': True},
+]"/>
+```
+
+In practice you wrap records in `<data noupdate="1">`. The convenience is important for demo data and user-editable defaults.
+
+### Recommended Defaults
+
+| Record Kind | `noupdate` |
+|-------------|-----------|
+| Views, menus, actions, reports | `0` (default) |
+| Scheduled jobs you want users to reconfigure | `1` |
+| Default records (sequences, warehouses, journals) | `1` |
+| Demo data | `1` (and inside `<data noupdate="1">`) |
+| Access-control records (`ir.model.access`) | `0` — keep in sync |
+| Record rules | `0` — keep in sync |
+
+### `forcecreate`
+
+Inside a `noupdate="1"` block, if a record referenced by id does not exist during upgrade, the loader will still create it. To opt out, add `forcecreate="0"` on the `<record>`:
+
+```xml
+<data noupdate="1">
+    <record id="optional_cron" model="ir.cron" forcecreate="0">
+        <field name="name">Optional Job</field>
+        ...
+    </record>
+</data>
+```
+
+---
+
+## Loading Order & Modes
+
+- Files are loaded in the order declared in `__manifest__.py` (`data:` then `demo:`).
+- Within a file, operations execute top-to-bottom. A later record can reference an earlier external id, but not the other way around.
+- Update mode (`-u my_module`) re-runs every file but skips `noupdate="1"` blocks and `<function>` calls.
+- Init mode (first install) runs everything, including `<function>` in `noupdate="1"` blocks.
+
+### Multiple `<data>` Blocks
+
+You can freely mix updatable and non-updatable blocks in one file:
+
+```xml
+<odoo>
+    <record id="view_x_form" model="ir.ui.view">...</record>
+
+    <data noupdate="1">
+        <record id="default_config" model="res.config.settings">...</record>
+    </data>
+
+    <record id="action_x" model="ir.actions.act_window">...</record>
+
+    <menuitem id="menu_x" name="X" action="action_x"/>
+</odoo>
+```
+
+---
+
+## Quick Reference
+
+### `<record>` and `<field>`
+
+```xml
+<record id="external_id" model="model.name" context="{}">
+    <field name="char_field">plain string</field>
+    <field name="boolean" eval="True"/>
+    <field name="m2o_field" ref="module.other_xmlid"/>
+    <field name="m2o_field" search="[('code','=','X')]"/>
+    <field name="m2m_field" eval="[Command.set([ref('a'), ref('b')])]"/>
+    <field name="html_field" type="html"><p>HTML content</p></field>
+    <field name="binary" type="base64" file="module/static/file.bin"/>
+    <field name="file_ref" type="file" name="module/static/x.png"/>
+    <field name="count" type="int">42</field>
+</record>
+```
+
+### Shortcuts
+
+```xml
+<menuitem id="m1" name="Label" parent="m_root" action="act_x" sequence="10"
+          groups="base.group_user"/>
+
+<template id="tpl" name="My Template" inherit_id="parent.tpl" priority="16">
+    <xpath expr="//div" position="inside"><p>Extra</p></xpath>
+</template>
+
+<asset id="bundle_x" name="Bundle">
+    <bundle>web.assets_backend</bundle>
+    <path>my_module/static/src/js/a.js</path>
+</asset>
+
+<report id="act_rep_x" string="My Report"
+        model="my.model" report_type="qweb-pdf"
+        name="my_module.tpl_report_x" file="my_module.report_x"/>
+```
+
+### `<delete>` / `<function>`
+
+```xml
+<delete model="res.partner" id="obsolete.legacy_partner"/>
+<delete model="ir.ui.menu" search="[('name','=','Old')]"/>
+
+<function model="res.partner" name="unlink_inactive"/>
+<function model="my.model" name="post_install_hook"
+          eval="[ref('base.main_company')]"/>
+```
+
+### Relational Commands
+
+| Command | Tuple | Meaning |
+|---------|-------|---------|
+| `Command.create({...})` | `(0, 0, {...})` | Create |
+| `Command.update(id, {...})` | `(1, id, {...})` | Update |
+| `Command.delete(id)` | `(2, id, 0)` | Delete |
+| `Command.unlink(id)` | `(3, id, 0)` | Unlink |
+| `Command.link(id)` | `(4, id, 0)` | Link |
+| `Command.clear()` | `(5, 0, 0)` | Clear |
+| `Command.set([ids])` | `(6, 0, [ids])` | Replace |
+
+---
+
+## Base Code Reference
+
+- `odoo/tools/convert.py` — XML data loader, all tag handlers (`_tag_record`, `_tag_delete`, `_tag_function`, `_tag_menuitem`, `_tag_template`, `_tag_asset`), `eval` context (`_get_idref`).
+- `odoo/addons/base/models/ir_model.py` — `ir.model.data` and the external-id resolver (`_xmlid_to_res_model_res_id`).
+- `odoo/addons/base/models/ir_ui_menu.py` — menu model backing `<menuitem>`.
+- `odoo/addons/base/models/ir_ui_view.py` — `ir.ui.view` backing `<template>`.
+- `odoo/fields.py` — `Command` helpers exposed in `eval`.

--- a/skills/odoo-16.0/references/odoo-16-decorator-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-decorator-guide.md
@@ -1,0 +1,578 @@
+---
+name: odoo-16-decorator
+description: Complete reference for Odoo 16 API decorators (@api.model, @api.model_create_multi, @api.depends, @api.depends_context, @api.constrains, @api.onchange, @api.ondelete, @api.returns, @api.autovacuum) and safe internal-helper naming patterns.
+globs: "**/models/**/*.py"
+topics:
+  - api.model (model-level methods)
+  - api.model_create_multi (batch create)
+  - api.depends (computed field dependencies)
+  - api.depends_context (context-dependent computes)
+  - api.constrains (data validation)
+  - api.onchange (form UI updates)
+  - api.ondelete (delete validation)
+  - api.returns (return type specification)
+  - api.autovacuum (daily cleanup)
+  - Internal helper naming (underscore-prefixed methods)
+  - Decorator combinations and decision tree
+when_to_use:
+  - Writing computed fields
+  - Implementing data validation
+  - Creating onchange handlers
+  - Preventing record deletion
+  - Defining model-level methods
+  - Batching create() overrides
+---
+
+# Odoo 16 Decorator Guide
+
+Complete reference for Odoo 16 `@api` decorators, including `@api.private`, plus the usual internal-helper naming patterns.
+
+## Table of Contents
+
+1. [@api.model](#apimodel)
+2. [@api.model_create_multi](#apimodel_create_multi)
+3. [@api.depends](#apidepends)
+4. [@api.depends_context](#apidepends_context)
+5. [@api.constrains](#apiconstrains)
+6. [@api.onchange](#apionchange)
+7. [@api.ondelete](#apiondelete)
+8. [@api.private and Internal Helpers](#apiprivate-and-internal-helpers)
+9. [@api.returns](#apireturns)
+10. [@api.autovacuum](#apiautovacuum)
+11. [Combinations](#combinations)
+12. [Decision Tree](#decision-tree)
+
+---
+
+## @api.model
+
+Marks a method where `self` is a recordset but its contents are irrelevant — only the model (class) matters. Use it for factories, class-level helpers, or methods callable as `self.env['my.model'].method(...)`.
+
+```python
+from odoo import api, fields, models
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    @api.model
+    def default_get(self, fields_list):
+        vals = super().default_get(fields_list)
+        vals['team_id'] = self.env.user.team_id.id
+        return vals
+
+    @api.model
+    def _default_pricelist(self):
+        return self.env['product.pricelist'].search([], limit=1)
+
+    pricelist_id = fields.Many2one(
+        'product.pricelist',
+        default=_default_pricelist,
+    )
+```
+
+Notes:
+
+- Over RPC, `@api.model` methods receive `self` as an empty recordset of the model.
+- For a method that takes a dict and is named `create`, `@api.model` automatically falls back to `@api.model_create_single` (see `odoo/api.py:378`). Do **not** rely on that fallback — in Odoo 16 you should explicitly use `@api.model_create_multi` when overriding `create()`.
+
+---
+
+## @api.model_create_multi
+
+**Required** decorator whenever you override `create()` in Odoo 16.
+
+```python
+from odoo import api, fields, models
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals.setdefault('state', 'draft')
+            if not vals.get('name'):
+                vals['name'] = self.env['ir.sequence'].next_by_code('sale.order')
+        orders = super().create(vals_list)
+        orders._post_create_hook()
+        return orders
+```
+
+The decorator adapts the callsite: callers may still pass a single `dict`, which the wrapper silently converts to `[dict]` before invoking the method (see `odoo/api.py:427`). That means `create()` always receives a **list** inside the method body.
+
+Failing to use `@api.model_create_multi` logs:
+
+```
+The model <module> is not overriding the create method in batch
+```
+
+and falls back to a slow per-record wrapper (`@api.model_create_single`) — every batched create call then loops one record at a time.
+
+**Never** decorate `create()` with `@api.model` in Odoo 16 — it silently degrades to single-record mode with a runtime warning.
+
+---
+
+## @api.depends
+
+Declares the fields whose changes should trigger recomputation of a computed field.
+
+```python
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    amount_untaxed = fields.Monetary()
+    tax_total      = fields.Monetary()
+    amount_total   = fields.Monetary(compute='_compute_amount_total', store=True)
+
+    @api.depends('amount_untaxed', 'tax_total')
+    def _compute_amount_total(self):
+        for order in self:
+            order.amount_total = order.amount_untaxed + order.tax_total
+```
+
+### Dotted paths (relational dependencies)
+
+```python
+@api.depends('partner_id.name', 'partner_id.email')
+def _compute_partner_display(self):
+    for order in self:
+        order.partner_display = f"{order.partner_id.name} <{order.partner_id.email}>"
+```
+
+### One2many traversal
+
+```python
+@api.depends('order_line.price_subtotal')
+def _compute_amount_untaxed(self):
+    for order in self:
+        order.amount_untaxed = sum(order.order_line.mapped('price_subtotal'))
+```
+
+### Dynamic dependencies
+
+Pass a callable for dependencies that vary by model configuration:
+
+```python
+@api.depends(lambda self: (self._rec_name,) if self._rec_name else ())
+def _compute_display_name(self):
+    ...
+```
+
+### Rules and caveats
+
+1. **Cannot depend on `id`** — Odoo raises `NotImplementedError("Compute method cannot depend on field 'id'.")` (see `odoo/api.py:267`).
+2. **List every field** you actually read — missing dependencies cause stale cached values.
+3. **Dotted paths OK** in `@api.depends` (but **not** in `@api.constrains` or `@api.onchange`).
+4. **Assign to every record** in `self` — even when you only care about a subset — so the ORM does not re-call the method for the missed ones.
+5. **Cycles** — add `recursive=True` on the field if the dependency path loops back (e.g. `parent_id.total`).
+
+---
+
+## @api.depends_context
+
+Tells the ORM that a **non-stored** computed field's value depends on some context keys. When any of those keys change, Odoo invalidates the cached value and re-computes.
+
+```python
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    price = fields.Float(compute='_compute_price')
+
+    @api.depends_context('pricelist')
+    def _compute_price(self):
+        pricelist_id = self.env.context.get('pricelist')
+        pricelist = self.env['product.pricelist'].browse(pricelist_id) if pricelist_id else None
+        for product in self:
+            product.price = (
+                pricelist._get_product_price(product, 1.0) if pricelist else product.list_price
+            )
+```
+
+Built-in context keys with special support (see `odoo/api.py:287`):
+
+| Key | Meaning |
+|-----|---------|
+| `'company'` | Current `env.company.id` (derived from `allowed_company_ids` or the user's company) |
+| `'uid'` | `(env.uid, env.su)` tuple — recomputed when the user or sudo flag changes |
+| `'lang'` | `env.context['lang']` |
+| `'active_test'` | Either from context, falling back to the field's configured default |
+| `'bin_size'`, `'bin_size_<field>'` | Treated as booleans — any truthy value collapses to `True` |
+
+Other keys are used as-is and must be **hashable** (lists are converted to tuples automatically).
+
+```python
+@api.depends_context('company')
+def _compute_balance(self):
+    for partner in self:
+        partner.balance = partner._compute_balance_for_company(self.env.company)
+
+@api.depends_context('show_cost')
+def _compute_display_price(self):
+    show_cost = self.env.context.get('show_cost', False)
+    for product in self:
+        product.display_price = product.standard_price if show_cost else product.list_price
+```
+
+Combine with `@api.depends` when the field depends on both regular fields and context:
+
+```python
+price = fields.Float(compute='_compute_price')
+
+@api.depends('list_price')
+@api.depends_context('pricelist')
+def _compute_price(self):
+    ...
+```
+
+---
+
+## @api.constrains
+
+Validates data integrity on the listed fields. Raise `ValidationError` on failure.
+
+```python
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    @api.constrains('date_order', 'validity_date')
+    def _check_dates(self):
+        for order in self:
+            if order.validity_date and order.validity_date < order.date_order.date():
+                raise ValidationError(_("Validity date cannot precede the order date."))
+
+    @api.constrains('order_line')
+    def _check_has_lines(self):
+        for order in self:
+            if not order.order_line:
+                raise ValidationError(_("A confirmed order must have at least one line."))
+```
+
+### Rules (from `odoo/api.py:100`)
+
+1. **Only simple field names.** Dotted paths (`'partner_id.name'`) are silently ignored.
+2. **Triggered only when listed fields are present in `create()` / `write()`** — if the field is not in the view or not in the vals dict, the constraint is **not** evaluated.
+3. Raise `ValidationError` (from `odoo.exceptions`). Using `UserError` for constraint failures is technically possible but semantically wrong.
+4. A constraint can list several fields; it fires whenever **any** of them is in the write.
+
+### Ensuring a constraint always runs
+
+If you need an absolute invariant (e.g. "a confirmed order must have at least one line") that must be checked even when the user does not touch `order_line`, override `create()` / `write()` and call the constraint method explicitly, or re-write the field to trigger the constraint:
+
+```python
+@api.model_create_multi
+def create(self, vals_list):
+    records = super().create(vals_list)
+    records._check_has_lines()
+    return records
+```
+
+---
+
+## @api.onchange
+
+Runs on the **form view** when the user edits one of the listed fields. The method is invoked on a **pseudo-record**: a single record holding the unsaved form values. Field assignments are sent back to the client.
+
+```python
+class SaleOrderLine(models.Model):
+    _name = 'sale.order.line'
+
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        if self.product_id:
+            self.price_unit = self.product_id.list_price
+            self.name       = self.product_id.display_name
+            self.product_uom_id = self.product_id.uom_id
+        else:
+            self.price_unit = 0.0
+            self.name = ''
+```
+
+### Warnings and notifications
+
+Return a dict with a `warning` key:
+
+```python
+@api.onchange('discount')
+def _onchange_discount(self):
+    if self.discount and self.discount > 50:
+        return {
+            'warning': {
+                'title': _("High Discount"),
+                'message': _("Discount above 50%% requires manager approval."),
+                'type': 'notification',   # 'dialog' (default) or 'notification'
+            }
+        }
+```
+
+### Dynamic domains
+
+Onchange can return a `domain` dict (field name -> domain) to filter Many2one dropdowns — but the Odoo 16 recommended pattern is to use the `domain=` attribute on the field itself or a `Char` `_domain` field referenced from the view. Returning a domain from onchange is still supported but has been demoted in the code base.
+
+### Rules (from `odoo/api.py:197`)
+
+1. **Only simple field names.** Dotted paths are ignored.
+2. **No CRUD on the pseudo-record.** Calling `create()`, `write()`, `unlink()` from inside an onchange is undefined behaviour — the record may not exist yet in the DB.
+3. **A one2many / many2many field cannot modify itself via onchange** (webclient limitation, issue #2693).
+4. Assign values directly (`self.field = value`) or use `self.update({'field': value})`.
+
+### Onchange is UI only
+
+Onchange does **not** run on server-side `create()` or `write()`. Any invariant that must hold in all cases must also be expressed as `@api.depends` / `@api.constrains`.
+
+---
+
+## @api.ondelete
+
+Preferred way to reject a deletion. Runs during `unlink()`; by default **skipped** during module uninstall so the uninstaller can still drop data.
+
+```python
+from odoo import api, models
+from odoo.exceptions import UserError
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_draft(self):
+        if any(order.state not in ('draft', 'cancel') for order in self):
+            raise UserError(_("Only draft or cancelled orders can be deleted."))
+```
+
+### Naming convention
+
+By convention the method is named:
+
+- `_unlink_if_<condition>` — raise when `<condition>` is true
+- `_unlink_except_<allowed_state>` — raise unless records are in the allowed state
+
+### at_uninstall
+
+| Value | Behaviour |
+|-------|-----------|
+| `False` (recommended) | Runs during normal use; **skipped** when the module is being uninstalled. |
+| `True` | Always runs — even during uninstall. Reserve for system-critical invariants (e.g. "the default language must not disappear"). |
+
+```python
+@api.ondelete(at_uninstall=True)
+def _unlink_if_default_language(self):
+    if self.env.ref('base.lang_en') in self:
+        raise UserError(_("Cannot delete the default language."))
+```
+
+### Why not override unlink()?
+
+Overriding `unlink()` for validation breaks module uninstallation: during uninstall, your check raises, the transaction rolls back, and leftover data stays in the DB. `@api.ondelete(at_uninstall=False)` is the supported way to add delete rules (available since Odoo 15).
+
+### Multiple ondelete methods
+
+You can decorate several methods on the same model; all of them run in declaration order.
+
+---
+
+## @api.private and Internal Helpers
+
+Odoo 16 provides `@api.private` to keep a method out of RPC exposure. The
+usual underscore-prefixed helper naming convention is still useful for internal
+worker methods.
+
+```python
+from odoo import api, models
+from odoo.exceptions import AccessError
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.private
+    def _refund_total(self, reason):
+        self.ensure_one()
+        self._post_refund(reason)
+        return self.amount_total
+
+    def action_refund_total(self, reason):
+        self.ensure_one()
+        if not self.env.user.has_group('sale.group_sale_manager'):
+            raise AccessError(_("Only Sales Managers can refund totals."))
+        return self._refund_total(reason)
+```
+
+Use `@api.private` for methods that must stay out of RPC on Odoo 16. Continue
+to use underscore-prefixed names for helpers such as `_compute_*`,
+`_prepare_*`, `_check_*`, and `_action_*` so the codebase stays idiomatic.
+
+Private methods still do not secure any public entry point by themselves. If a
+method should remain callable from buttons, server actions, or external
+integrations, keep the public entry point non-underscored and perform access
+checks there before delegating.
+
+---
+
+## @api.returns
+
+Declares the model of the recordset returned by a method. Affects how the method's result is adapted when called via XML-RPC.
+
+```python
+class Partner(models.Model):
+    _name = 'res.partner'
+
+    @api.returns('self')
+    def copy(self, default=None):
+        return super().copy(default)
+
+    @api.returns('res.partner')
+    def get_main_contact(self):
+        return self.mapped('contact_ids')[:1]
+```
+
+When the method is invoked from the Python record-style API, the result is returned as a recordset. When invoked over XML-RPC, Odoo downgrades the recordset to ids (`list[int]`) automatically.
+
+Advanced form with `upgrade` / `downgrade` converters:
+
+```python
+@api.returns('mail.message', lambda value: value.id)
+def message_post(self, **kwargs):
+    ...
+```
+
+Here, when a caller uses the traditional RPC style, the message record is downgraded to its id. Inheritance is automatic: a subclass overriding `message_post` inherits the `@api.returns` declaration.
+
+---
+
+## @api.autovacuum
+
+Registers a method to be run by the daily `ir.autovacuum` cron job. The method name **must** start with `_` (the decorator asserts this).
+
+```python
+from datetime import timedelta
+from odoo import api, fields, models
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    @api.autovacuum
+    def _gc_orphan_attachments(self):
+        threshold = fields.Datetime.now() - timedelta(days=30)
+        self.search([
+            ('res_model', '=', False),
+            ('create_date', '<', threshold),
+        ]).unlink()
+```
+
+Use this for lightweight GC tasks that would otherwise need their own `ir.cron` record. Autovacuum methods are called with `self` as an empty recordset of the model.
+
+---
+
+## Combinations
+
+### Computed + stored + searchable + writable
+
+```python
+full_name = fields.Char(
+    compute='_compute_full_name',
+    inverse='_inverse_full_name',
+    search='_search_full_name',
+    store=True,
+)
+
+@api.depends('first_name', 'last_name')
+def _compute_full_name(self):
+    for r in self:
+        r.full_name = f"{r.first_name or ''} {r.last_name or ''}".strip()
+
+def _inverse_full_name(self):
+    for r in self:
+        parts = (r.full_name or '').split(' ', 1)
+        r.first_name = parts[0]
+        r.last_name  = parts[1] if len(parts) > 1 else ''
+
+def _search_full_name(self, operator, value):
+    return ['|', ('first_name', operator, value), ('last_name', operator, value)]
+```
+
+### @api.depends + @api.depends_context
+
+```python
+price = fields.Float(compute='_compute_price')
+
+@api.depends('list_price')
+@api.depends_context('pricelist', 'uid')
+def _compute_price(self):
+    ...
+```
+
+Both decorators stack: the compute is re-run when either a listed field or one of the listed context keys changes.
+
+### @api.model with @api.constrains
+
+`@api.constrains` is normally a record-level decorator, but you can combine it with `@api.model` when the check itself does not iterate (rarely useful):
+
+```python
+@api.model
+@api.constrains('code')
+def _check_code_format(self):
+    for rec in self:
+        if rec.code and not rec.code.isalnum():
+            raise ValidationError(_("Code must be alphanumeric."))
+```
+
+### Batch create + constrains
+
+```python
+@api.model_create_multi
+def create(self, vals_list):
+    records = super().create(vals_list)
+    records._check_business_rules()    # force invariants missing from vals
+    return records
+```
+
+---
+
+## Decision Tree
+
+```
+Defining / overriding a FIELD
+├── Computed from other fields? ............ @api.depends
+│   └── Also needs context?  ............... + @api.depends_context
+│   └── Should be searchable? .............. store=True OR search=...
+│   └── Should be writable? ................ inverse=...
+│
+Defining / overriding a METHOD
+├── Overriding create()? ................... @api.model_create_multi (REQUIRED)
+├── Model-level (self content irrelevant)? . @api.model
+├── Validates integrity? ................... @api.constrains (simple field names only)
+├── Form UI reaction? ...................... @api.onchange (no CRUD, no dotted paths)
+├── Deletion guard? ........................ @api.ondelete(at_uninstall=False)
+├── Daily cleanup job? ..................... @api.autovacuum (method must be private _)
+├── Internal helper only? .................. Prefix the method with `_`
+├── Returns a recordset via RPC? ........... @api.returns('model' or 'self')
+└── Regular record-level method ............ no decorator
+```
+
+---
+
+## Quick Reference
+
+| Decorator / Pattern | Purpose | Dotted paths? | Notes |
+|---------------------|---------|---------------|-------|
+| `@api.model` | Method where self content is irrelevant | — | Also fallback-handles `create(single_dict)` but use `model_create_multi` instead |
+| `@api.model_create_multi` | Batch-capable `create()` override | — | **Required** in v16 when overriding `create()` |
+| `@api.depends(*fields)` | Compute dependencies | Yes | Cannot depend on `'id'` |
+| `@api.depends_context(*keys)` | Context dependencies | — | Values must be hashable |
+| `@api.constrains(*fields)` | Data validation | No | Only runs when listed fields are in vals |
+| `@api.onchange(*fields)` | Form UI reaction | No | No CRUD on pseudo-record |
+| `@api.ondelete(at_uninstall=False)` | Deletion guard | — | Preferred over overriding `unlink()` |
+| Underscore-prefixed helper | Keep method out of RPC | — | Use `_helper_name`; there is no Odoo 16 `@api` decorator for this |
+| `@api.returns(model, ...)` | Declare return-model for RPC | — | Inherited by overrides automatically |
+| `@api.autovacuum` | Daily cleanup | — | Method name must start with `_` |
+
+---
+
+## Base Code Reference
+
+Verify decorator semantics in:
+
+- `/Users/unclecat/odoo/16.0/odoo/api.py` — all supported Odoo 16 `@api` decorators (`model` L369, `model_create_multi` L434, `depends` L246, `depends_context` L271, `constrains` L100, `onchange` L197, `ondelete` L138, `returns` L297, `autovacuum` L358).
+- `/Users/unclecat/odoo/16.0/odoo/models.py` — `@api.model_create_multi` usage on `create()` (line 4561), recomputation engine interacting with `@api.depends`, and the `ir.autovacuum` cron target.
+- `/Users/unclecat/odoo/16.0/odoo/exceptions.py` — `ValidationError`, `UserError`, `MissingError` to raise from decorated methods.

--- a/skills/odoo-16.0/references/odoo-16-development-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-development-guide.md
@@ -1,0 +1,964 @@
+---
+name: odoo-16-development
+description: Overview guide for authoring Odoo 16 modules — directory structure, __init__.py patterns, wizards (TransientModel), report declarations, security files, asset bundles, i18n/.pot, and static assets.
+globs: "**/*.{py,xml,csv}"
+topics:
+  - Standard Odoo 16 module directory structure
+  - __init__.py patterns (root, models/, wizard/, controllers/)
+  - Wizards with models.TransientModel
+  - Report declaration (actions + QWeb templates)
+  - Security files in `data` (order matters)
+  - Asset bundles available in Odoo 16
+  - i18n folder with .pot template + locale .po files
+  - Static assets layout (description/icon.png, src/, lib/)
+when_to_use:
+  - Scaffolding a new Odoo 16 module
+  - Adding a wizard, report, or controllers subpackage
+  - Setting up translations for a module
+  - Deciding where an asset/file belongs
+---
+
+# Odoo 16 Development Guide
+
+Module creation overview for Odoo 16: directory structure, `__init__.py`
+patterns, wizards, reports, security, asset bundles, i18n, and static assets.
+For the full `__manifest__.py` reference see
+[`odoo-16-manifest-guide.md`](./odoo-16-manifest-guide.md). For migration
+scripts see [`odoo-16-migration-guide.md`](./odoo-16-migration-guide.md).
+
+## Table of Contents
+
+1. [Module Structure](#module-structure)
+2. [`__init__.py` Patterns](#__init__py-patterns)
+3. [`__manifest__.py` (quick)](#__manifest__py-quick)
+4. [Security Declaration](#security-declaration)
+5. [Reports](#reports)
+6. [Wizards & `TransientModel`](#wizards--transientmodel)
+7. [Data Files](#data-files)
+8. [Asset Bundles](#asset-bundles)
+9. [Static Assets Layout](#static-assets-layout)
+10. [i18n Folder (.pot + locale .po)](#i18n-folder-pot--locale-po)
+11. [Complete Module Skeleton](#complete-module-skeleton)
+12. [Base Code Reference](#base-code-reference)
+
+---
+
+## Module Structure
+
+Standard Odoo 16 module skeleton:
+
+```
+my_module/
+├── __init__.py                      # Python package init (imports submodules)
+├── __manifest__.py                  # Module manifest (REQUIRED)
+│
+├── models/
+│   ├── __init__.py
+│   ├── my_model.py                  # models.Model subclasses
+│   └── res_partner.py               # inherits / extensions
+│
+├── wizard/
+│   ├── __init__.py
+│   ├── my_wizard.py                 # models.TransientModel subclasses
+│   └── my_wizard_views.xml
+│
+├── controllers/
+│   ├── __init__.py
+│   └── main.py                      # http.Controller subclasses
+│
+├── views/
+│   ├── my_model_views.xml
+│   ├── my_model_templates.xml       # QWeb website templates
+│   └── my_module_menus.xml
+│
+├── security/
+│   ├── my_module_groups.xml         # res.groups, categories
+│   ├── ir_rule.xml                  # ir.rule record rules
+│   └── ir.model.access.csv          # Model-level ACL
+│
+├── data/
+│   ├── ir_sequence_data.xml
+│   ├── ir_cron_data.xml
+│   └── mail_template_data.xml
+│
+├── demo/
+│   └── my_module_demo.xml
+│
+├── report/
+│   ├── my_report_actions.xml        # ir.actions.report
+│   └── my_report_templates.xml      # QWeb templates
+│
+├── migrations/
+│   └── 16.0.1.0.0/
+│       ├── pre-migrate.py
+│       ├── post-migrate.py
+│       └── end-migrate.py
+│
+├── i18n/
+│   ├── my_module.pot                # Translation template (REQUIRED)
+│   ├── vi.po                        # Vietnamese
+│   └── fr.po                        # Optional additional locales
+│
+├── static/
+│   ├── description/
+│   │   ├── icon.png                 # Shown in Apps list
+│   │   └── index.html               # Optional marketing page
+│   └── src/
+│       ├── js/
+│       │   └── my_component.js
+│       ├── xml/
+│       │   └── my_component.xml     # OWL templates
+│       ├── scss/
+│       │   └── my_component.scss
+│       └── img/
+│           └── logo.svg
+│
+└── tests/
+    ├── __init__.py
+    └── test_my_model.py
+```
+
+Optional subfolders:
+
+- `lib/` — bundled third-party Python modules (avoid; prefer
+  `external_dependencies`).
+- `populate/` — `populate` CLI data generators.
+- `report/` / `reports/` — both names work; pick one and be consistent.
+
+---
+
+## `__init__.py` Patterns
+
+### Module root `__init__.py`
+
+```python
+# my_module/__init__.py
+from odoo import SUPERUSER_ID, api
+
+from . import controllers
+from . import models
+from . import wizard
+
+# Hooks referenced from __manifest__.py.
+# In Odoo 16, `pre_init_hook` receives `cr`, while `post_init_hook` and
+# `uninstall_hook` receive `(cr, registry)`. Build an Environment manually
+# inside the hook when you need ORM access.
+
+def pre_init_hook(cr):
+    """Runs before install (fresh installs only)."""
+    pass
+
+
+def post_init_hook(cr, registry):
+    """Runs after install (fresh installs only)."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['ir.config_parameter'].sudo().set_param('my_module.enabled', 'True')
+
+
+def uninstall_hook(cr, registry):
+    """Runs when the module is removed."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['ir.config_parameter'].sudo().search([
+        ('key', '=like', 'my_module.%')
+    ]).unlink()
+
+
+def post_load():
+    """Runs once per server process when the Python module is imported.
+       No arguments, no database access guaranteed."""
+    pass
+```
+
+### `models/__init__.py`
+
+```python
+# my_module/models/__init__.py
+from . import my_model
+from . import res_partner
+```
+
+Each file inside `models/` defines one or more classes inheriting from
+`models.Model` (or `models.AbstractModel`).
+
+### `wizard/__init__.py`
+
+```python
+# my_module/wizard/__init__.py
+from . import my_wizard
+```
+
+### `controllers/__init__.py`
+
+```python
+# my_module/controllers/__init__.py
+from . import main
+```
+
+### `tests/__init__.py`
+
+```python
+# my_module/tests/__init__.py
+from . import test_my_model
+```
+
+Tests are only auto-loaded when `--test-enable` is active.
+
+---
+
+## `__manifest__.py` (quick)
+
+For the full reference, see `odoo-16-manifest-guide.md`. Minimum viable
+manifest:
+
+```python
+# my_module/__manifest__.py
+{
+    'name': 'My Module',
+    'version': '16.0.1.0.0',
+    'summary': 'Short description',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'category': 'Tools',
+    'depends': ['base'],
+    'data': [
+        'security/my_module_groups.xml',
+        'security/ir.model.access.csv',
+        'views/my_model_views.xml',
+        'views/my_module_menus.xml',
+    ],
+    'demo': [
+        'demo/my_module_demo.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}
+```
+
+**Ordering in `data`:** security first → reference data → wizards → views →
+reports → menus last. Menus reference actions, so actions must be loaded
+before them.
+
+---
+
+## Security Declaration
+
+Security files must be listed in `data` **first**, because every view that
+references a group or a model needs those records to already exist.
+
+### Files
+
+```
+security/
+├── my_module_groups.xml       # res.groups records
+├── ir_rule.xml                # Record rules
+└── ir.model.access.csv        # Model-level access control
+```
+
+### Manifest entry (order)
+
+```python
+'data': [
+    'security/my_module_groups.xml',     # groups first (rules reference them)
+    'security/ir_rule.xml',              # then rules
+    'security/ir.model.access.csv',      # then ACL
+    # ...views, reports, menus...
+],
+```
+
+### `ir.model.access.csv`
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model user,model_my_model,base.group_user,1,1,1,0
+access_my_model_manager,my.model manager,model_my_model,my_module.group_my_module_manager,1,1,1,1
+```
+
+- `model_id:id` uses the auto-generated ID `model_<model_name_with_underscores>`.
+- Empty `group_id:id` means every user with the implicit public group.
+
+### Groups
+
+```xml
+<!-- security/my_module_groups.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="module_category_my_module" model="ir.module.category">
+        <field name="name">My Module</field>
+        <field name="sequence">20</field>
+    </record>
+
+    <record id="group_my_module_user" model="res.groups">
+        <field name="name">User</field>
+        <field name="category_id" ref="module_category_my_module"/>
+    </record>
+
+    <record id="group_my_module_manager" model="res.groups">
+        <field name="name">Manager</field>
+        <field name="category_id" ref="module_category_my_module"/>
+        <field name="implied_ids" eval="[(4, ref('group_my_module_user'))]"/>
+    </record>
+</odoo>
+```
+
+### Record rules
+
+```xml
+<!-- security/ir_rule.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="my_model_personal_rule" model="ir.rule">
+        <field name="name">My Model: own records</field>
+        <field name="model_id" ref="model_my_model"/>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('group_my_module_user'))]"/>
+    </record>
+
+    <record id="my_model_manager_rule" model="ir.rule">
+        <field name="name">My Model: all records</field>
+        <field name="model_id" ref="model_my_model"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('group_my_module_manager'))]"/>
+    </record>
+</odoo>
+```
+
+For the full security reference see `odoo-16-security-guide.md`.
+
+---
+
+## Reports
+
+### Files
+
+```
+report/
+├── my_report_actions.xml            # ir.actions.report
+└── my_report_templates.xml          # QWeb templates
+```
+
+Declared in `data` **before** menus but **after** views (reports may be
+referenced from view buttons):
+
+```python
+'data': [
+    # ...security, data, views...
+    'report/my_report_templates.xml',
+    'report/my_report_actions.xml',
+    'views/my_module_menus.xml',
+],
+```
+
+### Action
+
+```xml
+<!-- report/my_report_actions.xml -->
+<odoo>
+    <record id="action_report_my_model" model="ir.actions.report">
+        <field name="name">My Model Report</field>
+        <field name="model">my.model</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">my_module.report_my_model</field>
+        <field name="report_file">my_module.report_my_model</field>
+        <field name="print_report_name">'My Model - %s' % (object.name)</field>
+        <field name="binding_model_id" ref="model_my_model"/>
+        <field name="binding_type">report</field>
+    </record>
+</odoo>
+```
+
+| `report_type` | Output |
+|---------------|--------|
+| `qweb-pdf`    | PDF via wkhtmltopdf. |
+| `qweb-html`   | HTML (viewed in browser). |
+| `qweb-text`   | Plain text (labels, barcodes). |
+
+### Template
+
+```xml
+<!-- report/my_report_templates.xml -->
+<odoo>
+    <template id="report_my_model_document">
+        <t t-call="web.external_layout">
+            <div class="page">
+                <h2 t-field="doc.name"/>
+                <p t-field="doc.description"/>
+            </div>
+        </t>
+    </template>
+
+    <template id="report_my_model">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <t t-call="my_module.report_my_model_document"/>
+            </t>
+        </t>
+    </template>
+</odoo>
+```
+
+Report CSS/SCSS goes into the `web.report_assets_common` bundle (see
+[Asset Bundles](#asset-bundles)).
+
+For the full reports reference see `odoo-16-reports-guide.md`.
+
+---
+
+## Wizards & `TransientModel`
+
+Wizards are short-lived models whose records are periodically purged (by
+default daily). Use them for dialogs, multi-step assistants, and actions
+triggered from a model's form view.
+
+### File layout
+
+```
+wizard/
+├── __init__.py
+├── my_wizard.py
+└── my_wizard_views.xml
+```
+
+### Python
+
+```python
+# wizard/my_wizard.py
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class MyWizard(models.TransientModel):
+    _name = 'my.wizard'
+    _description = 'My Action Wizard'
+
+    date = fields.Date(default=fields.Date.context_today, required=True)
+    reason = fields.Text()
+    user_id = fields.Many2one('res.users', default=lambda self: self.env.user)
+
+    record_ids = fields.Many2many(
+        'my.model',
+        string='Records',
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if 'record_ids' in fields_list and self.env.context.get('active_model') == 'my.model':
+            res['record_ids'] = [(6, 0, self.env.context.get('active_ids', []))]
+        return res
+
+    def action_apply(self):
+        self.ensure_one()
+        if not self.record_ids:
+            raise UserError('Select at least one record.')
+        for rec in self.record_ids:
+            rec.action_done(self.date, self.reason)
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Applied',
+                'message': f'Processed {len(self.record_ids)} records',
+                'type': 'success',
+            },
+        }
+```
+
+### View
+
+```xml
+<!-- wizard/my_wizard_views.xml -->
+<odoo>
+    <record id="view_my_wizard_form" model="ir.ui.view">
+        <field name="name">my.wizard.form</field>
+        <field name="model">my.wizard</field>
+        <field name="arch" type="xml">
+            <form string="My Wizard">
+                <group>
+                    <field name="date"/>
+                    <field name="user_id"/>
+                </group>
+                <group>
+                    <field name="reason"/>
+                </group>
+                <field name="record_ids" invisible="1"/>
+                <footer>
+                    <button string="Apply" name="action_apply" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_my_wizard" model="ir.actions.act_window">
+        <field name="name">Run My Wizard</field>
+        <field name="res_model">my.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>
+```
+
+Declared in `data`:
+
+```python
+'data': [
+    # ...security...
+    'wizard/my_wizard_views.xml',
+    # ...views, menus...
+],
+```
+
+### `TransientModel` vs `Model`
+
+| | `TransientModel` | `Model` |
+|---|------------------|---------|
+| Lifetime | Auto-GC (default: rows >1 day old). | Permanent. |
+| DB table | Yes. | Yes. |
+| `_name` | Convention: end with `.wizard`. | Free. |
+| Use case | Wizards, confirmation dialogs, one-shot actions. | Business data. |
+
+---
+
+## Data Files
+
+### Records
+
+```xml
+<!-- data/my_module_data.xml -->
+<odoo>
+    <record id="my_config_1" model="my.model">
+        <field name="name">Default</field>
+        <field name="code">DEFAULT</field>
+    </record>
+
+    <!-- noupdate="1" means module upgrades will NOT overwrite user edits. -->
+    <record id="my_config_editable" model="my.model" noupdate="1">
+        <field name="name">Customizable</field>
+    </record>
+</odoo>
+```
+
+### Cron jobs
+
+```xml
+<odoo>
+    <record id="ir_cron_my_model_cleanup" model="ir.cron">
+        <field name="name">Clean old my.model records</field>
+        <field name="model_id" ref="model_my_model"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_cleanup()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="active" eval="True"/>
+    </record>
+</odoo>
+```
+
+For exhaustive data-file syntax see `odoo-16-data-guide.md` and
+`odoo-16-actions-guide.md`.
+
+---
+
+## Asset Bundles
+
+Asset bundles in Odoo 16 (verified against `addons/web/__manifest__.py`):
+
+| Bundle | Use for |
+|--------|---------|
+| `web.assets_backend` | Backend JS, SCSS, and OWL XML templates. |
+| `web.assets_common` | Shared assets loaded by both backend and frontend entry points. |
+| `web.assets_frontend` | Website/portal assets. |
+| `web.assets_tests` | Tour/integration test assets. |
+| `web.qunit_suite_tests` | Desktop QUnit test suites. |
+| `web.qunit_mobile_suite_tests` | Mobile QUnit tests. |
+| `web.report_assets_common` | SCSS/JS used when rendering QWeb reports. |
+| `web.report_assets_pdf` | Extra PDF-only CSS. |
+| `web._assets_primary_variables` | Primary SCSS variables (early include, e.g. theme colors). |
+| `web._assets_secondary_variables` | Secondary SCSS variables. |
+
+### Declaring in `__manifest__.py`
+
+```python
+'assets': {
+    'web.assets_backend': [
+        'my_module/static/src/scss/form_override.scss',
+        'my_module/static/src/js/**/*.js',
+        'my_module/static/src/xml/**/*.xml',         # OWL templates
+    ],
+    'web.assets_frontend': [
+        'my_module/static/src/js/portal.js',
+        'my_module/static/src/scss/portal.scss',
+    ],
+    'web.report_assets_common': [
+        'my_module/static/src/scss/report.scss',
+    ],
+    'web.assets_tests': [
+        'my_module/static/tests/tours/**/*',
+    ],
+    'web.qunit_suite_tests': [
+        'my_module/static/tests/**/*',
+        ('remove', 'my_module/static/tests/tours/**/*'),
+    ],
+}
+```
+
+### Operations recap
+
+| Operation | Shape |
+|-----------|-------|
+| Include entire bundle | `('include', 'web._assets_core')` |
+| Remove a glob already in the bundle | `('remove', 'my_module/static/src/js/exp.js')` |
+| Prepend | `('prepend', 'my_module/static/src/scss/vars.scss')` |
+| Insert after / before a specific file | `('after', '<anchor>', '<new>')` / `('before', ...)` |
+| Replace | `('replace', '<old>', '<new>')` |
+
+---
+
+## Static Assets Layout
+
+```
+static/
+├── description/
+│   ├── icon.png                 # 128×128 recommended; shown in Apps list
+│   └── index.html               # (optional) Apps-store marketing page
+└── src/
+    ├── js/
+    │   ├── components/
+    │   │   └── my_widget.js     # OWL component (JS)
+    │   └── services/
+    │       └── my_service.js
+    ├── xml/
+    │   └── my_widget.xml        # OWL template (paired with the JS file)
+    ├── scss/
+    │   └── my_widget.scss
+    ├── css/
+    │   └── plain.css            # CSS that isn't SCSS
+    ├── lib/                     # Bundled third-party libs (avoid where possible)
+    └── img/
+        └── logo.svg
+```
+
+Conventions:
+
+- OWL components live in `static/src/js/` with a matching `.xml` template in
+  `static/src/xml/` (or colocated, then include both with the same glob).
+- `static/description/icon.png` is picked up automatically by the Apps UI —
+  you do not declare it in the manifest.
+- Third-party libraries go in `static/lib/` (each library in its own
+  subfolder).
+
+---
+
+## i18n Folder (.pot + locale .po)
+
+**Every Odoo module ships an `i18n/` folder.** The folder must contain:
+
+1. A `.pot` template named after the module (`<module>.pot`) — the machine-
+   extractable strings.
+2. One `.po` file per supported locale (e.g. `vi.po`, `fr.po`).
+
+```
+i18n/
+├── my_module.pot          # REQUIRED: translation template
+├── vi.po                  # Vietnamese
+└── fr.po                  # Optional extras
+```
+
+The `.pot` file is not loaded at install; it is the source of truth for
+translators. Locale `.po` files *are* loaded automatically (Odoo scans the
+`i18n/` folder when installing or updating the module).
+
+### Generating the `.pot`
+
+From the Odoo server:
+
+```bash
+./odoo-bin -d <db> --modules=my_module --i18n-export=my_module/i18n/my_module.pot
+```
+
+Or from Settings → Translations → Export Translations (UI), selecting
+`New language (Empty template)` + the module.
+
+### `my_module.pot` skeleton
+
+```po
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* my_module
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-23 00:00+0000\n"
+"PO-Revision-Date: 2026-04-23 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: my_module
+#: model:ir.model,name:my_module.model_my_model
+msgid "My Model"
+msgstr ""
+
+#. module: my_module
+#: model:ir.model.fields,field_description:my_module.field_my_model__name
+msgid "Name"
+msgstr ""
+```
+
+### `vi.po` skeleton
+
+```po
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* my_module
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-23 00:00+0000\n"
+"PO-Revision-Date: 2026-04-23 00:00+0000\n"
+"Language-Team: Vietnamese <vi@li.org>\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: my_module
+#: model:ir.model,name:my_module.model_my_model
+msgid "My Model"
+msgstr "Mô hình của tôi"
+
+#. module: my_module
+#: model:ir.model.fields,field_description:my_module.field_my_model__name
+msgid "Name"
+msgstr "Tên"
+```
+
+For the full translation workflow see `odoo-16-translation-guide.md`.
+
+---
+
+## Complete Module Skeleton
+
+### Files
+
+```
+business_trip/
+├── __init__.py
+├── __manifest__.py
+├── models/
+│   ├── __init__.py
+│   └── business_trip.py
+├── wizard/
+│   ├── __init__.py
+│   ├── business_trip_cancel.py
+│   └── business_trip_cancel_views.xml
+├── controllers/
+│   ├── __init__.py
+│   └── main.py
+├── views/
+│   ├── business_trip_views.xml
+│   └── business_trip_menus.xml
+├── security/
+│   ├── business_trip_groups.xml
+│   ├── ir_rule.xml
+│   └── ir.model.access.csv
+├── data/
+│   └── ir_sequence_data.xml
+├── demo/
+│   └── business_trip_demo.xml
+├── report/
+│   ├── business_trip_report_actions.xml
+│   └── business_trip_report_templates.xml
+├── migrations/
+│   └── 16.0.1.0.0/
+│       └── post-migrate.py
+├── i18n/
+│   ├── business_trip.pot
+│   └── vi.po
+├── static/
+│   ├── description/
+│   │   └── icon.png
+│   └── src/
+│       ├── js/
+│       │   └── trip_form.js
+│       ├── xml/
+│       │   └── trip_form.xml
+│       └── scss/
+│           └── trip.scss
+└── tests/
+    ├── __init__.py
+    └── test_business_trip.py
+```
+
+### `__manifest__.py`
+
+```python
+# -*- coding: utf-8 -*-
+{
+    'name': 'Business Trip Management',
+    'version': '16.0.1.0.0',
+    'summary': 'Plan trips and track expenses',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'category': 'Human Resources',
+    'depends': ['base', 'mail', 'hr'],
+    'data': [
+        'security/business_trip_groups.xml',
+        'security/ir_rule.xml',
+        'security/ir.model.access.csv',
+        'data/ir_sequence_data.xml',
+        'wizard/business_trip_cancel_views.xml',
+        'views/business_trip_views.xml',
+        'report/business_trip_report_templates.xml',
+        'report/business_trip_report_actions.xml',
+        'views/business_trip_menus.xml',
+    ],
+    'demo': [
+        'demo/business_trip_demo.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'business_trip/static/src/js/trip_form.js',
+            'business_trip/static/src/xml/trip_form.xml',
+            'business_trip/static/src/scss/trip.scss',
+        ],
+    },
+    'post_init_hook': 'post_init_hook',
+    'uninstall_hook': 'uninstall_hook',
+    'installable': True,
+    'application': True,
+}
+```
+
+### `__init__.py`
+
+```python
+# business_trip/__init__.py
+from odoo import SUPERUSER_ID, api
+
+from . import controllers
+from . import models
+from . import wizard
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['ir.config_parameter'].sudo().set_param('business_trip.enabled', 'True')
+
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['ir.config_parameter'].sudo().search([
+        ('key', '=like', 'business_trip.%')
+    ]).unlink()
+```
+
+### `models/business_trip.py`
+
+```python
+from odoo import api, fields, models
+
+
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+    _description = 'Business Trip'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _order = 'date_start desc'
+
+    name = fields.Char(required=True, tracking=True)
+    date_start = fields.Date(required=True, tracking=True)
+    date_end = fields.Date(required=True)
+    employee_id = fields.Many2one('hr.employee', required=True, tracking=True)
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('confirmed', 'Confirmed'),
+        ('done', 'Done'),
+        ('cancel', 'Cancelled'),
+    ], default='draft', tracking=True)
+
+    def action_confirm(self):
+        self.write({'state': 'confirmed'})
+
+    def action_done(self, date=None, reason=None):
+        self.write({'state': 'done'})
+```
+
+### `security/ir.model.access.csv`
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_business_trip_user,business.trip user,model_business_trip,business_trip.group_business_trip_user,1,1,1,0
+access_business_trip_manager,business.trip manager,model_business_trip,business_trip.group_business_trip_manager,1,1,1,1
+```
+
+### `i18n/business_trip.pot`
+
+```po
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-23 00:00+0000\n"
+"PO-Revision-Date: 2026-04-23 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: business_trip
+#: model:ir.model,name:business_trip.model_business_trip
+msgid "Business Trip"
+msgstr ""
+```
+
+### `i18n/vi.po`
+
+```po
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Language-Team: Vietnamese <vi@li.org>\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: business_trip
+#: model:ir.model,name:business_trip.model_business_trip
+msgid "Business Trip"
+msgstr "Chuyến công tác"
+```
+
+---
+
+## Base Code Reference
+
+- `odoo/modules/module.py` — module discovery, `_DEFAULT_MANIFEST`, manifest
+  loading (`load_manifest`, `get_manifest`), version normalization
+  (`adapt_version`).
+- `odoo/modules/loading.py` — module initialization and hook invocation.
+  `pre_init_hook` uses a cursor-only entry point in v16, while
+  `post_init_hook` and `uninstall_hook` are called with `(cr, registry)`.
+  Build `api.Environment(cr, SUPERUSER_ID, {})` inside the hook when ORM
+  access is needed.
+- `addons/web/__manifest__.py` — authoritative list of asset bundles in v16
+  (`web.assets_backend`, `web.assets_frontend`, `web.report_assets_common`,
+  `web.assets_tests`, `web.qunit_suite_tests`, …). Note there is **no**
+  `web.assets_common` in v16.
+- `odoo/addons/base/models/ir_asset.py` — `ir.asset` model used to manage
+  bundle entries at runtime.
+- `odoo/addons/base/models/ir_model.py`, `ir_rule.py` — security records.
+- `odoo/release.py` — `major_version = '16.0'`.

--- a/skills/odoo-16.0/references/odoo-16-field-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-field-guide.md
@@ -1,0 +1,726 @@
+---
+name: odoo-16-field
+description: Complete reference for Odoo 16 field types, parameters, and when to use each. Use this guide when defining model fields, choosing field types, or configuring field parameters.
+globs: "**/models/**/*.py"
+topics:
+  - Simple fields (Char, Text, Html, Boolean, Integer, Float, Monetary, Date, Datetime, Binary, Image, Selection, Reference)
+  - Relational fields (Many2one, One2many, Many2many, Many2oneReference)
+  - Json and Properties fields
+  - Computed fields (compute, store, search, inverse)
+  - Related fields
+  - Field parameters (index, default, copy, store, groups, company_dependent, tracking, group_operator)
+when_to_use:
+  - Defining new model fields
+  - Choosing appropriate field types
+  - Configuring computed fields
+  - Setting up relational fields
+  - Optimizing field parameters
+---
+
+# Odoo 16 Field Guide
+
+Complete reference for Odoo 16 field types, parameters, and when to use each.
+
+## Table of Contents
+
+1. [Simple Fields](#simple-fields)
+2. [Relational Fields](#relational-fields)
+3. [Json and Properties](#json-and-properties)
+4. [Computed Fields](#computed-fields)
+5. [Related Fields](#related-fields)
+6. [Field Parameters](#field-parameters)
+7. [Indexes](#indexes)
+8. [Defaults](#defaults)
+9. [Field Type Selection Guide](#field-type-selection-guide)
+
+---
+
+## Simple Fields
+
+### Char - Short Text
+
+```python
+name = fields.Char(
+    string='Name',
+    required=True,
+    size=128,            # UI hint; not enforced at DB level
+    translate=True,      # per-language values stored in jsonb
+    default='',
+)
+
+code = fields.Char(string='Code', index=True, copy=False)
+```
+
+Use for short free-form strings (names, references, codes). Strings stored in a `varchar` column.
+
+### Text - Long Text
+
+```python
+description = fields.Text(string='Description', translate=True)
+notes       = fields.Text(string='Notes')
+```
+
+Use for multi-line plain text. Backed by a `text` column (no length limit).
+
+### Html - Rich Text
+
+```python
+content = fields.Html(
+    string='Content',
+    translate=True,
+    sanitize=True,                       # default True - strip dangerous tags
+    sanitize_attributes=True,
+    sanitize_style=False,
+    strip_style=False,
+    strip_classes=False,
+)
+```
+
+Use for HTML fragments (email bodies, CMS content). The sanitizer removes `<script>`, event handlers, and similar vectors by default.
+
+### Boolean
+
+```python
+active = fields.Boolean(default=True)
+is_company = fields.Boolean(string='Is a Company')
+```
+
+Stored as `boolean`. Default when unset: `False`.
+
+### Integer
+
+```python
+sequence = fields.Integer(default=10)
+priority = fields.Integer(default=0)
+```
+
+Stored as `int4`. For large counters use `Float` or dedicated columns. On the
+`Integer` class, `group_operator = 'sum'` by default; set
+`group_operator=None` explicitly on sequence-like fields when you do not want
+group totals.
+
+### Float
+
+```python
+# Fixed digits (precision, scale)
+weight = fields.Float(
+    string='Weight',
+    digits=(16, 3),       # total digits, decimal places
+)
+
+# Named precision from decimal.precision records
+price = fields.Float(
+    string='Unit Price',
+    digits='Product Price',
+)
+```
+
+**Always use the named precision form for domain-specific numbers** (prices, quantities) — it lets the user configure precision at `Settings > Technical > Decimal Accuracy` without code changes.
+
+For currency amounts, use `Monetary`, not `Float`.
+
+Helper methods (static, on `fields.Float`, backed by `odoo.tools.float_utils`):
+
+```python
+# Round to precision
+rounded = fields.Float.round(value, precision_rounding=0.01)
+
+# Check zero at precision
+if fields.Float.is_zero(qty, precision_rounding=self.uom_id.rounding):
+    raise UserError(_("Quantity cannot be zero."))
+
+# Compare at precision
+cmp = fields.Float.compare(a, b, precision_rounding=0.01)
+# cmp < 0  -> a < b
+# cmp == 0 -> equal (within precision)
+# cmp > 0  -> a > b
+```
+
+Use these helpers instead of native `==` / `<` comparisons to avoid floating-point drift.
+
+### Monetary
+
+```python
+currency_id = fields.Many2one('res.currency', required=True)
+
+amount = fields.Monetary(
+    string='Amount',
+    currency_field='currency_id',     # REQUIRED: points to a res.currency m2o
+)
+
+# If you already have a company_id and want its currency:
+company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
+company_currency_id = fields.Many2one(related='company_id.currency_id')
+amount = fields.Monetary(string='Amount', currency_field='company_currency_id')
+```
+
+Monetary fields format to the currency's digits and respect its rounding. Mixing currencies in the same list view forces `Monetary` aggregates into `sum` with automatic currency awareness.
+
+### Date
+
+```python
+date_order = fields.Date(
+    string='Order Date',
+    default=fields.Date.context_today,   # callable: today in user's TZ
+    copy=False,
+)
+```
+
+Stored as `date` (no time, no timezone). Helper API (see `odoo/fields.py:2137`):
+
+```python
+fields.Date.today()                              # date.today() (server TZ)
+fields.Date.context_today(record)                # today in record.env.user TZ
+fields.Date.to_date('2024-01-15')                # str -> date
+fields.Date.to_string(fields.Date.today())       # date -> 'YYYY-MM-DD'
+
+# Period math (from odoo.tools.date_utils)
+fields.Date.start_of(fields.Date.today(), 'month')
+fields.Date.end_of(fields.Date.today(), 'quarter')
+fields.Date.add(fields.Date.today(), months=1)
+fields.Date.subtract(fields.Date.today(), weeks=2)
+# granularities: year, quarter, month, week, day, hour
+```
+
+### Datetime
+
+```python
+date_deadline = fields.Datetime(
+    string='Deadline',
+    default=fields.Datetime.now,     # UTC now at creation
+)
+```
+
+Stored as `timestamp without time zone` in UTC. Displayed in the user's timezone.
+
+Helper API (see `odoo/fields.py:2241`):
+
+```python
+fields.Datetime.now()                            # utcnow
+fields.Datetime.today()                          # today @ 00:00:00 UTC
+fields.Datetime.to_datetime('2024-01-15 14:30:00')
+fields.Datetime.to_string(fields.Datetime.now())
+fields.Datetime.context_timestamp(record, dt)    # UTC -> user TZ
+fields.Datetime.start_of(fields.Datetime.now(), 'day')
+fields.Datetime.add(fields.Datetime.now(), hours=1)
+```
+
+### Binary
+
+```python
+file_data = fields.Binary(
+    string='File',
+    attachment=True,      # default True - stored as ir.attachment, not in table
+)
+filename = fields.Char(string='Filename')
+```
+
+With `attachment=True` (the default), content goes into the filestore via `ir.attachment` — the model table only holds a pointer. Pair with a `Char` for the filename.
+
+When reading Binary fields you usually want small metadata (size + mimetype), not raw bytes — use the `bin_size` context:
+
+```python
+self.env['ir.attachment'].with_context(bin_size=True).search([...])
+# field value is returned as a human-readable size ("1.23 Kb") instead of bytes
+```
+
+### Image
+
+```python
+image_1920 = fields.Image(
+    string='Image',
+    max_width=1920,
+    max_height=1920,
+    verify_resolution=True,        # default True - rejects images over ~50 Mpx
+)
+
+# Resized derivatives (Odoo adds tools/views to convert on the fly)
+image_512  = fields.Image(related='image_1920', max_width=512, max_height=512, store=True)
+```
+
+`Image` extends `Binary` and resizes on `create` / `write` while keeping aspect ratio. If both `max_width` and `max_height` are `0` and `verify_resolution=False`, no processing happens — use plain `Binary` instead.
+
+`Image` fields require `_log_access=True` on the model (the default); the framework warns otherwise.
+
+### Selection
+
+```python
+state = fields.Selection(
+    [
+        ('draft', 'Draft'),
+        ('confirmed', 'Confirmed'),
+        ('done', 'Done'),
+        ('cancel', 'Cancelled'),
+    ],
+    string='Status',
+    default='draft',
+    required=True,
+    tracking=True,        # available when inheriting mail.thread
+)
+
+# Dynamic selection from a method
+kind = fields.Selection(selection='_selection_kind', string='Kind')
+
+@api.model
+def _selection_kind(self):
+    return [(k, k.title()) for k in self._get_kinds()]
+```
+
+Selection values are stored as their **keys** in the DB (`varchar`), so never rename an existing key without a migration script.
+
+Extend a Selection in a child module with `selection_add`:
+
+```python
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    state = fields.Selection(
+        selection_add=[('locked', 'Locked')],
+        ondelete={'locked': 'set default'},
+    )
+```
+
+### Reference
+
+```python
+ref = fields.Reference(
+    selection='_selection_target_model',
+    string='Referenced Record',
+)
+
+@api.model
+def _selection_target_model(self):
+    return [(m.model, m.name) for m in self.env['ir.model'].search([])]
+```
+
+Stored as a `'model,id'` string — flexible but poor for indexes/joins. Prefer `Many2oneReference` when you already store the model name in a separate `Char`.
+
+### Many2oneReference
+
+```python
+res_model = fields.Char(string='Resource Model', index=True)
+res_id    = fields.Many2oneReference(
+    string='Resource ID',
+    model_field='res_model',   # Char that holds the target model name
+    index=True,
+)
+```
+
+Stored as an integer FK-less id. Much faster than `Reference` for lookups and joins. This is the pattern used by `ir.attachment`, `mail.followers`, etc.
+
+---
+
+## Relational Fields
+
+### Many2one
+
+```python
+partner_id = fields.Many2one(
+    comodel_name='res.partner',
+    string='Customer',
+    required=True,
+    ondelete='restrict',      # 'cascade', 'set null', 'restrict'
+    domain="[('customer_rank', '>', 0)]",
+    context={'default_customer_rank': 1},
+    tracking=True,
+    index=True,
+    check_company=True,       # pair with _check_company_auto on the model
+)
+
+# Default callable -> current user's partner
+partner_id = fields.Many2one(
+    'res.partner',
+    default=lambda self: self.env.user.partner_id,
+)
+
+# Delegation inheritance (_inherits pattern)
+partner_id = fields.Many2one('res.partner', required=True, ondelete='cascade', delegate=True)
+```
+
+`ondelete` values:
+
+| Value | Behaviour on referenced-record deletion |
+|-------|----------------------------------------|
+| `'set null'` (default) | Set FK column to `NULL` |
+| `'cascade'` | Delete this record as well |
+| `'restrict'` | Refuse to delete the referenced record |
+
+### One2many
+
+```python
+line_ids = fields.One2many(
+    comodel_name='sale.order.line',
+    inverse_name='order_id',       # REQUIRED - the Many2one on the child model
+    string='Order Lines',
+    copy=True,
+    auto_join=False,               # True to generate SQL JOINs on search
+)
+
+# Filtered shadow O2M
+active_line_ids = fields.One2many(
+    'sale.order.line',
+    'order_id',
+    domain=[('state', '!=', 'cancel')],
+    string='Active Lines',
+)
+```
+
+The child model must declare the reverse `Many2one` with the same name you pass to `inverse_name`. `One2many` is virtual — no DB column lives on the parent table.
+
+`copy=True` on `One2many` duplicates the child records when the parent is copied.
+
+### Many2many
+
+```python
+tag_ids = fields.Many2many(
+    comodel_name='res.partner.category',
+    relation='sale_order_tag_rel',    # optional - DB table name
+    column1='order_id',               # optional - this side's FK column
+    column2='tag_id',                 # optional - comodel side's FK column
+    string='Tags',
+    domain=[('active', '=', True)],
+)
+
+# Minimal form - Odoo generates table & columns from the field name
+category_ids = fields.Many2many('res.partner.category', string='Categories')
+```
+
+Pass `relation`, `column1`, `column2` explicitly when two `Many2many` fields target the same comodel from the same model, otherwise Odoo's auto-generated relation name will collide.
+
+---
+
+## Json and Properties
+
+### Json (beta)
+
+```python
+config = fields.Json(string='Configuration')
+# Stored in a jsonb column. Values are deep-copied on read.
+```
+
+Odoo 16's `Json` field is marked experimental in the source (`odoo/fields.py:3288`) — searching, indexing, and partial mutation are not supported. Treat the value as immutable: assign a fresh dict rather than mutating `record.config['x'] = 1` (the ORM will not detect the change).
+
+### Properties
+
+```python
+class ProjectTask(models.Model):
+    _name = 'project.task'
+
+    project_id = fields.Many2one('project.project', required=True)
+    user_properties = fields.Properties(
+        string='Properties',
+        definition='project_id.task_properties_definition',
+        copy=True,
+    )
+
+class Project(models.Model):
+    _name = 'project.project'
+
+    task_properties_definition = fields.PropertiesDefinition(string='Task Properties')
+```
+
+`Properties` lets a parent record define ad-hoc sub-fields (type + default) that child records can fill in. The values are stored as `jsonb` on the child; the definition lives on the parent. Allowed property types in Odoo 16 are `boolean`, `integer`, `float`, `char`, `date`, `datetime`, `many2one`, `many2many`, `selection`, and `tags`.
+
+---
+
+## Computed Fields
+
+### Non-stored Compute
+
+```python
+subtotal = fields.Monetary(compute='_compute_subtotal', currency_field='currency_id')
+
+@api.depends('price_unit', 'quantity')
+def _compute_subtotal(self):
+    for line in self:
+        line.subtotal = line.price_unit * line.quantity
+```
+
+Non-stored computed fields are evaluated on read. They **must** assign a value to every record in `self` (including when `self` is empty) — otherwise Odoo raises `CacheMiss` when the field is later accessed.
+
+### Stored Compute
+
+```python
+amount_total = fields.Monetary(
+    compute='_compute_amount_total',
+    store=True,                       # persisted, searchable, indexable
+    currency_field='currency_id',
+)
+
+@api.depends('line_ids.price_subtotal')
+def _compute_amount_total(self):
+    for order in self:
+        order.amount_total = sum(order.line_ids.mapped('price_subtotal'))
+```
+
+Add `store=True` to make the field searchable/groupable and to avoid recomputation at every read. Dependencies in `@api.depends` determine when the value gets recomputed.
+
+### Inverse (write back)
+
+```python
+full_name = fields.Char(compute='_compute_full_name', inverse='_inverse_full_name', store=True)
+
+@api.depends('first_name', 'last_name')
+def _compute_full_name(self):
+    for rec in self:
+        rec.full_name = f"{rec.first_name or ''} {rec.last_name or ''}".strip()
+
+def _inverse_full_name(self):
+    for rec in self:
+        parts = (rec.full_name or '').split(' ', 1)
+        rec.first_name = parts[0]
+        rec.last_name  = parts[1] if len(parts) > 1 else ''
+```
+
+`inverse` gives a computed field write support. The method must not be decorated with `@api.depends` — it is triggered on write, not on recompute.
+
+### search (for non-stored computes)
+
+```python
+display_ref = fields.Char(compute='_compute_display_ref', search='_search_display_ref')
+
+def _search_display_ref(self, operator, value):
+    return ['|', ('name', operator, value), ('ref', operator, value)]
+```
+
+`search=` turns a non-stored computed field into a searchable one by mapping domain clauses to real-field clauses.
+
+### Recursive Dependencies
+
+```python
+total = fields.Float(
+    compute='_compute_total',
+    store=True,
+    recursive=True,            # REQUIRED when the field depends on itself through a relation
+)
+
+@api.depends('child_ids.total', 'own_amount')
+def _compute_total(self):
+    for rec in self:
+        rec.total = rec.own_amount + sum(rec.child_ids.mapped('total'))
+```
+
+Without `recursive=True`, Odoo refuses to register a self-dependent compute graph.
+
+### precompute (compute at create time)
+
+```python
+sequence = fields.Char(
+    compute='_compute_sequence',
+    store=True,
+    precompute=True,          # compute during create(), before INSERT
+)
+```
+
+`precompute=True` avoids an extra `UPDATE` right after `INSERT`. It only makes sense on **stored, computed** fields. A warning is emitted when used on a non-computed or non-stored field. Beware that default values disable precomputation, and that precompute can slow down batches that would otherwise benefit from recompute flushing (see `odoo/fields.py:239`).
+
+### compute_sudo
+
+```python
+amount = fields.Float(compute='_compute_amount', store=True, compute_sudo=True)
+```
+
+When `compute_sudo=True`, the compute method runs with `su=True` so it can access fields the current user cannot read. Defaults: `True` for stored computes, `False` for non-stored.
+
+---
+
+## Related Fields
+
+### Basic Related
+
+```python
+partner_name = fields.Char(related='partner_id.name', readonly=True)
+
+# Store a related field -> it becomes searchable and indexable
+partner_country_id = fields.Many2one(related='partner_id.country_id', store=True, index=True)
+```
+
+Related fields are implemented as computes internally. They are read-only by default; add `readonly=False` to let users write to them (the write is forwarded to the target field).
+
+### Multi-level Related
+
+```python
+country_code = fields.Char(
+    related='partner_id.country_id.code',
+    string='Country Code',
+    readonly=True,
+)
+```
+
+### Company-dependent Related
+
+```python
+company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
+company_currency_id = fields.Many2one(related='company_id.currency_id', readonly=True)
+```
+
+---
+
+## Field Parameters
+
+### Common Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `string` | str | capitalized field name | Label shown in UI |
+| `help` | str | `None` | Tooltip |
+| `required` | bool | `False` | Validation: value must be set |
+| `readonly` | bool | `False` (or `True` for computed / related) | UI only; writes from code still work on stored fields |
+| `default` | value or callable | `None` | Static or `lambda self: ...` |
+| `copy` | bool | `True` for scalars, `False` for one2many / computed | Included by `copy()` |
+| `store` | bool | `True` for scalars, `False` for computed / related | Persist to DB |
+| `index` | `False` / `True` / `'btree'` / `'btree_not_null'` / `'trigram'` | `None` | Create a DB index |
+| `translate` | bool or callable | `False` | Per-language storage |
+| `groups` | str | `None` | CSV of group xml ids that may read/write this field |
+| `company_dependent` | bool | `False` | Per-company value stored in `ir.property` |
+| `compute` | str | `None` | Name of compute method |
+| `inverse` | str | `None` | Name of inverse method |
+| `search` | str | `None` | Name of search method for non-stored computes |
+| `compute_sudo` | bool | `True` for stored computes, else `False` | Recompute as superuser |
+| `precompute` | bool | `False` | Compute during `create()` (before INSERT) |
+| `recursive` | bool | `False` | Declare self-referential dependency |
+| `related` | str | `None` | Dotted path replacing the field's storage |
+| `group_operator` | str | type-dependent (`'sum'` for numeric, `None` for sequence/many2one_reference) | Aggregator used by `read_group()` |
+| `group_expand` | str | `None` | Method name used to expand empty groups |
+| `tracking` | bool or int | `False` | With `mail.thread`: log field changes in chatter (`True` / `1`-`100` priority) |
+
+### group_operator (Odoo 16)
+
+Odoo 16 uses `group_operator=` to control how `read_group()` aggregates a field in list / pivot views. Valid values are:
+
+`sum`, `avg`, `max`, `min`, `count`, `count_distinct`, `bool_and`, `bool_or`, `array_agg`.
+
+```python
+amount = fields.Float(string='Amount', group_operator='sum')   # default for numeric types
+
+# Disable the default aggregation (useful for id-like numeric fields)
+sequence = fields.Integer(string='Sequence', group_operator=None)
+
+# Boolean aggregation
+is_paid = fields.Boolean(group_operator='bool_and')
+```
+
+Note: v16 uses `group_operator=`. Later versions renamed this parameter to `aggregator=`. In v16 source code, `aggregator=` will raise a parameter-unknown error (or be silently stored as an unknown key).
+
+### Tracking (requires mail.thread)
+
+```python
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+    _inherit = ['mail.thread']
+
+    state = fields.Selection([...], tracking=True)
+    amount_total = fields.Monetary(tracking=20)     # priority, lower = shown first
+```
+
+`tracking` is contributed by the `mail` module; it only takes effect on models that inherit `mail.thread`.
+
+### company_dependent
+
+```python
+property_payment_term_id = fields.Many2one(
+    'account.payment.term',
+    company_dependent=True,
+    string='Default Payment Terms',
+)
+```
+
+Company-dependent fields are not stored on the model's own table; they are kept as `ir.property` records keyed by company. Writing to them creates / updates the property for the current company. Reading them resolves to the value of the current company.
+
+---
+
+## Indexes
+
+```python
+code       = fields.Char(index=True)                  # equivalent to 'btree'
+name       = fields.Char(index='trigram')             # full-text ilike
+category_id = fields.Many2one(index='btree_not_null') # mostly NULL column
+parent_path = fields.Char(index=True)                 # required by _parent_store
+```
+
+Options (from `odoo/fields.py:152`):
+
+| Value | Meaning |
+|-------|---------|
+| `True` / `'btree'` | Standard B-tree index. Good for equality / many2one joins. |
+| `'btree_not_null'` | B-tree that excludes `NULL`. Saves space when the column is mostly null. |
+| `'trigram'` | PostgreSQL `pg_trgm` index. Required for fast `ilike '%term%'` matching. |
+| `None` / `False` | No index (default). |
+
+Indexes only apply to **stored** fields. Adding `index=True` to a non-stored computed field is a no-op.
+
+Odoo 16 uses the `index=` field parameter as the only way to declare indexes in model code. There is no `models.Index(...)` helper (that was introduced in later versions). For composite indexes, add them in SQL within a post-init hook or via migration scripts.
+
+---
+
+## Defaults
+
+```python
+# Static value
+active = fields.Boolean(default=True)
+priority = fields.Integer(default=0)
+
+# Callable (evaluated per record on create)
+date = fields.Date(default=fields.Date.context_today)
+datetime = fields.Datetime(default=fields.Datetime.now)
+
+# Lambda reading env
+user_id = fields.Many2one(
+    'res.users',
+    default=lambda self: self.env.user,
+)
+company_id = fields.Many2one(
+    'res.company',
+    default=lambda self: self.env.company,
+)
+
+# Method referenced by name (use @api.model on the method)
+ref = fields.Char(default='_default_ref')
+
+@api.model
+def _default_ref(self):
+    return self.env['ir.sequence'].next_by_code('my.model') or '/'
+```
+
+The callable signature is `default(self)` where `self` is an empty recordset of the model. It must **not** write to the database — `create()` is not reentrant from within a default.
+
+Defaults defined in XML context (e.g. `default_partner_id` in an action's context) override the field's own `default=`.
+
+---
+
+## Field Type Selection Guide
+
+| Requirement | Use |
+|-------------|-----|
+| Short text (name, code) | `Char` |
+| Long plain text | `Text` |
+| Rich text (HTML) | `Html` |
+| Yes / No | `Boolean` |
+| Whole number | `Integer` |
+| Decimal (non-currency) | `Float` (with `digits='Named Precision'`) |
+| Money | `Monetary` (+ `currency_field`) |
+| Date only | `Date` |
+| Date + time | `Datetime` |
+| File attachment | `Binary(attachment=True)` |
+| Image (with resize) | `Image` |
+| Fixed list of choices | `Selection` |
+| Dynamic reference (arbitrary model) | `Reference` |
+| Dynamic reference (efficient, model stored separately) | `Many2oneReference` |
+| Link to one record | `Many2one` |
+| Link to many records (inverse side) | `One2many` (with `inverse_name`) |
+| Many-to-many relation | `Many2many` |
+| Ad-hoc user-defined sub-fields | `Properties` |
+| Derived from other fields | `compute=...` |
+| Projection of a related record's field | `related='path.to.field'` |
+| Per-company value | `company_dependent=True` |
+
+---
+
+## Base Code Reference
+
+Verify every parameter/type described here against:
+
+- `/Users/unclecat/odoo/16.0/odoo/fields.py` — all field classes (`Field`, `Char`, `Float`, `Monetary`, `Date`, `Datetime`, `Binary`, `Image`, `Selection`, `Reference`, `Many2one`, `Many2oneReference`, `One2many`, `Many2many`, `Json`, `Properties`, `Command`).
+- `/Users/unclecat/odoo/16.0/odoo/models.py` — `VALID_AGGREGATE_FUNCTIONS`, `_check_company_auto`, `_parent_store`, `_sql_constraints`.
+- `/Users/unclecat/odoo/16.0/odoo/tools/date_utils.py` — `start_of`, `end_of`, `add`, `subtract` used by `fields.Date` / `fields.Datetime`.
+- `/Users/unclecat/odoo/16.0/odoo/tools/float_utils.py` — `float_round`, `float_is_zero`, `float_compare` used by `fields.Float`.

--- a/skills/odoo-16.0/references/odoo-16-manifest-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-manifest-guide.md
@@ -1,0 +1,874 @@
+---
+name: odoo-16-manifest
+description: Complete reference for Odoo 16 module manifest (__manifest__.py) covering every valid key, dependencies, data loading order, assets, external dependencies, hooks, auto_install, version scheme, and license identifiers.
+globs: "**/__manifest__.py"
+topics:
+  - Every valid __manifest__.py key in Odoo 16
+  - Module dependencies and loading order
+  - `data` list ordering (security first, views last)
+  - Assets bundles (web.assets_backend, web.assets_frontend, web.report_assets_common, etc.)
+  - External dependencies (python, bin)
+  - Hooks (pre_init_hook, post_init_hook, uninstall_hook, post_load)
+  - auto_install (bool or list of dependencies)
+  - `installable`, `application`, `sequence`
+  - Version scheme 16.0.X.Y.Z
+  - License identifiers
+when_to_use:
+  - Authoring a new Odoo 16 module manifest
+  - Configuring module dependencies or assets
+  - Declaring external Python/binary dependencies
+  - Setting up module lifecycle hooks
+  - Deciding between `auto_install=True` and an explicit trigger set
+---
+
+# Odoo 16 Module Manifest Guide
+
+Complete reference for Odoo 16 `__manifest__.py`: every valid key, the `_DEFAULT_MANIFEST` defaults, dependencies, assets, hooks, and version rules.
+
+## Table of Contents
+
+1. [Manifest Basics](#manifest-basics)
+2. [Default Values (`_DEFAULT_MANIFEST`)](#default-values-_default_manifest)
+3. [Core Identification Fields](#core-identification-fields)
+4. [Version Scheme (`16.0.X.Y.Z`)](#version-scheme-160xyz)
+5. [License Identifiers](#license-identifiers)
+6. [Dependencies](#dependencies)
+7. [Data Loading](#data-loading)
+8. [Assets](#assets)
+9. [External Dependencies](#external-dependencies)
+10. [Hooks](#hooks)
+11. [Other Fields](#other-fields)
+12. [Complete Example](#complete-example)
+13. [Common Patterns](#common-patterns)
+14. [Base Code Reference](#base-code-reference)
+
+---
+
+## Manifest Basics
+
+### File Name
+
+Odoo 16 looks for these filenames (in order), via `MANIFEST_NAMES` in
+`odoo/modules/module.py`:
+
+```python
+MANIFEST_NAMES = ('__manifest__.py', '__openerp__.py')
+```
+
+- Always use `__manifest__.py`.
+- `__openerp__.py` is accepted but raises `DeprecationWarning` (removed in a
+  future major version).
+
+### Manifest Shape
+
+The file must evaluate (via `ast.literal_eval`) to a single Python `dict`
+literal. No imports, no function calls, no expressions — just literals:
+
+```python
+# -*- coding: utf-8 -*-
+{
+    'name': 'My Module',
+    'version': '16.0.1.0.0',
+    'depends': ['base'],
+    'data': [],
+    'installable': True,
+    'license': 'LGPL-3',
+    'author': 'UncleCat',
+}
+```
+
+### Minimal Installable Manifest
+
+```python
+{
+    'name': 'My Module',
+    'version': '16.0.1.0.0',
+    'license': 'LGPL-3',
+    'author': 'UncleCat',
+    'depends': ['base'],
+    'installable': True,
+}
+```
+
+---
+
+## Default Values (`_DEFAULT_MANIFEST`)
+
+Every key the v16 loader understands appears in `_DEFAULT_MANIFEST`
+(`odoo/modules/module.py`). Keys not in your manifest fall back to these
+defaults:
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `name` | — | **Required.** |
+| `version` | `'1.0'` | Gets normalized to `'16.0.1.0'` by `adapt_version`. |
+| `license` | `'LGPL-3'` | Warning emitted if missing. |
+| `author` | `'Odoo S.A.'` | Override in every custom module. |
+| `category` | `'Uncategorized'` | |
+| `summary` | `''` | One-line description. |
+| `description` | `''` | RST; falls back to `README.rst/md/txt` if empty. |
+| `website` | `''` | |
+| `sequence` | `100` | Ordering in Apps list. |
+| `depends` | `[]` | |
+| `data` | `[]` | |
+| `demo` | `[]` | |
+| `demo_xml` | `[]` | Legacy alias, avoid. |
+| `init_xml` | `[]` | Legacy alias, avoid. |
+| `update_xml` | `[]` | Legacy alias, avoid. |
+| `test` | `[]` | Legacy test declarations, avoid. |
+| `installable` | `True` | |
+| `application` | `False` | |
+| `auto_install` | `False` | `True`, `False`, or an iterable of module names. |
+| `assets` | `{}` | Asset bundles. |
+| `external_dependencies` | `[]` | Python/bin requirements. |
+| `pre_init_hook` | `''` | Name of function in the module's package. |
+| `post_init_hook` | `''` | Same. |
+| `uninstall_hook` | `''` | Same. |
+| `post_load` | `''` | Server-wide hook run at module import. |
+| `images` | `[]` | Screenshot paths. |
+| `images_preview_theme` | `{}` | Website themes only. |
+| `live_test_url` | `''` | Website themes only. |
+| `snippet_lists` | `{}` | Website themes only. |
+| `web` | `False` | Internal flag, do not set. |
+| `bootstrap` | `False` | Used by the `web` module only. |
+
+Keys not listed here (e.g. `maintainer`) are accepted as plain metadata — they
+are stored but not interpreted by the loader.
+
+---
+
+## Core Identification Fields
+
+### `name` (required)
+
+```python
+'name': 'Business Trip Management',
+```
+
+Human-readable name shown in the Apps list.
+
+### `summary`
+
+```python
+'summary': 'Plan business trips and track expenses',
+```
+
+One-line description shown under the module title in the Apps list.
+
+### `description`
+
+```python
+'description': """
+Business Trip Management
+========================
+Manage business trips, per-diems, and expense reports.
+""",
+```
+
+reStructuredText. If empty, Odoo reads `README.rst`, `README.md`, or
+`README.txt` from the module directory (see `load_manifest`).
+
+### `author`
+
+```python
+'author': 'UncleCat',
+```
+
+Can be a person, company, or comma-separated list:
+
+```python
+'author': 'UncleCat, Acme Corp.',
+```
+
+### `website`
+
+```python
+'website': 'https://example.com',
+```
+
+### `category`
+
+```python
+'category': 'Sales/Subscriptions',
+```
+
+Slashes create a hierarchy (`Sales` → `Subscriptions`). Common values include
+`Accounting`, `Human Resources`, `Inventory`, `Manufacturing`, `Marketing`,
+`Point of Sale`, `Productivity/Discuss`, `Project`, `Sales`, `Services`,
+`Tools`, `Warehouse`, `Website`, `Hidden` (for technical-only modules).
+
+### `maintainer`
+
+```python
+'maintainer': 'UncleCat',
+```
+
+Not in `_DEFAULT_MANIFEST`; stored as metadata. Defaults to `author` if
+consumers read it.
+
+---
+
+## Version Scheme (`16.0.X.Y.Z`)
+
+### Format
+
+Odoo 16 enforces that `version` must match one of these shapes (see
+`adapt_version` in `odoo/modules/module.py`):
+
+```
+x.y
+x.y.z
+16.0.x.y
+16.0.x.y.z
+```
+
+If the prefix is missing, the loader prepends `16.0.` automatically:
+
+```python
+'version': '1.0.0'        # becomes '16.0.1.0.0'
+'version': '16.0.1.0.0'   # stays  '16.0.1.0.0'
+```
+
+### Recommended
+
+Always write the full form so the manifest is self-documenting and so migration
+folders line up with the declared version:
+
+```python
+'version': '16.0.1.0.0',
+```
+
+Interpretation (convention, not enforced):
+
+- `16.0` — target Odoo series.
+- `1` — MAJOR of the module (incompatible schema changes).
+- `0` — MINOR (backwards-compatible feature additions).
+- `0` — PATCH (bug fixes).
+
+### Bumping for Migrations
+
+The migration runner compares `parsed_installed_version` against
+`current_version`. Migration scripts under `migrations/16.0.1.1.0/` only run
+when you bump from `16.0.1.0.0` to `16.0.1.1.0` or higher. Always bump the
+version in the manifest **before** committing a migration script.
+
+---
+
+## License Identifiers
+
+The loader warns if `license` is missing and falls back to `LGPL-3`. Always
+declare it explicitly. Valid values include:
+
+| Identifier | Description |
+|------------|-------------|
+| `LGPL-3` | GNU Lesser General Public License v3 (Odoo default). |
+| `GPL-2` | GNU General Public License v2. |
+| `GPL-2 or any later version` | |
+| `GPL-3` | GNU General Public License v3. |
+| `GPL-3 or any later version` | |
+| `AGPL-3` | GNU Affero General Public License v3. |
+| `OEEL-1` | Odoo Enterprise Edition License v1.0 (Enterprise addons). |
+| `OPL-1` | Odoo Proprietary License v1.0. |
+| `Other OSI approved licence` | Any OSI-approved license. |
+| `Other proprietary` | Closed-source custom license. |
+
+---
+
+## Dependencies
+
+### `depends`
+
+```python
+'depends': ['base', 'mail', 'product'],
+```
+
+List of modules that must be installed before this one. Odoo resolves the
+dependency graph and installs/loads them first.
+
+- Always include `base` (sometimes transitive, but explicit is better).
+- Depend on `mail` when you use `mail.thread` / `mail.activity.mixin`.
+- Avoid circular dependencies — the loader will error out.
+
+### `auto_install`
+
+Three accepted shapes (`odoo/modules/module.py`, `load_manifest`):
+
+```python
+# 1) Opt-in (default)
+'auto_install': False,
+
+# 2) Auto-install once every module in `depends` is installed
+'auto_install': True,
+
+# 3) Auto-install once this specific subset is installed
+#    (Subset must be a subset of `depends`.)
+'auto_install': ['sale', 'purchase'],
+```
+
+Shape #3 is used by bridge modules: they declare `depends: ['sale',
+'purchase']` and `auto_install: ['sale', 'purchase']`, meaning they appear
+automatically when both Sales and Purchase are installed.
+
+The loader asserts `auto_install ⊆ depends`:
+
+```
+AssertionError: auto_install triggers must be dependencies, found
+non-dependencies [...] for module <name>
+```
+
+---
+
+## Data Loading
+
+### `data`
+
+```python
+'data': [
+    # 1. Security FIRST (groups, ACL, record rules) — views reference them.
+    'security/res_groups.xml',
+    'security/ir_rules.xml',
+    'security/ir.model.access.csv',
+
+    # 2. Reference data (sequences, parameters, templates)
+    'data/ir_sequence_data.xml',
+    'data/mail_template_data.xml',
+
+    # 3. Wizards
+    'wizard/my_wizard_views.xml',
+
+    # 4. Views
+    'views/my_model_views.xml',
+    'views/res_partner_views.xml',
+
+    # 5. Reports (templates + actions)
+    'report/my_report_templates.xml',
+    'report/my_report_actions.xml',
+
+    # 6. Menus LAST — they reference window actions defined above.
+    'views/my_menus.xml',
+],
+```
+
+**Ordering rules:**
+
+1. **Security first.** `ir.model.access.csv` and groups must exist before any
+   view that references them.
+2. **Records before their references.** A view that sets `action_id` must come
+   after the action.
+3. **Menus last.** They usually reference actions defined earlier.
+4. **Wizards before view bindings** that embed wizard buttons.
+
+Paths are relative to the module root. Absolute paths and `../` are rejected.
+
+### `demo`
+
+```python
+'demo': [
+    'demo/my_module_demo.xml',
+],
+```
+
+Loaded **only** when the database is created with `--demo=all` (or equivalent).
+`data` is loaded on install *and* update; `demo` is loaded on install *only*
+when demo mode is active.
+
+| Attribute | When loaded |
+|-----------|-------------|
+| `data` | Install AND update. |
+| `demo` | Install in demo mode only. |
+
+### `demo_xml`, `init_xml`, `update_xml`, `test`
+
+Legacy aliases from Odoo 7 and earlier. Do not use in new v16 modules — they
+exist in `_DEFAULT_MANIFEST` only for backwards compatibility.
+
+---
+
+## Assets
+
+### Structure
+
+Assets are a dict of *bundle name → list of glob patterns*:
+
+```python
+'assets': {
+    'web.assets_backend': [
+        'my_module/static/src/js/**/*.js',
+        'my_module/static/src/xml/**/*.xml',
+        'my_module/static/src/scss/style.scss',
+    ],
+    'web.assets_frontend': [
+        'my_module/static/src/js/portal.js',
+    ],
+    'web.report_assets_common': [
+        'my_module/static/src/scss/report.scss',
+    ],
+}
+```
+
+### Bundles Available in Odoo 16
+
+Verified against `addons/web/__manifest__.py` in the v16 source:
+
+| Bundle | Purpose |
+|--------|---------|
+| `web.assets_backend` | Backend (web client) JS/CSS/XML. |
+| `web.assets_common` | Shared JS/CSS loaded by both backend and frontend entry points. |
+| `web.assets_frontend` | Website / portal assets. |
+| `web.assets_frontend_minimal` | Minimal frontend polyfills / module loader. |
+| `web.assets_frontend_lazy` | Lazily loaded frontend bundle. |
+| `web.assets_tests` | Tour/integration test assets. |
+| `web.tests_assets` | QUnit test runtime. |
+| `web.qunit_suite_tests` | Desktop QUnit test suites. |
+| `web.qunit_mobile_suite_tests` | Mobile QUnit suites. |
+| `web.report_assets_common` | SCSS/JS included when rendering QWeb reports (PDF/HTML). |
+| `web.report_assets_pdf` | Extra CSS for PDF-only rendering. |
+| `web.pdf_js_lib` | pdf.js library (lazy loaded). |
+| `web._assets_primary_variables` | Primary SCSS variables (early include). |
+| `web._assets_secondary_variables` | Secondary SCSS variables. |
+| `web._assets_helpers` / `web._assets_core` / `web._assets_bootstrap*` | Private sub-bundles referenced via `('include', ...)`. |
+
+### Operations
+
+Each entry in a bundle list is either a string (glob path) or a 2/3-tuple
+operation:
+
+```python
+'web.assets_backend': [
+    # plain include
+    'my_module/static/src/js/core.js',
+
+    # glob
+    'my_module/static/src/js/components/**/*.js',
+
+    # relative operations
+    ('include',  'web._assets_backend_helpers'),
+    ('remove',   'my_module/static/src/js/experimental.js'),
+    ('prepend',  'my_module/static/src/scss/vars.scss'),
+    ('replace',  'other_module/static/src/js/thing.js', 'my_module/static/src/js/thing.js'),
+    ('after',    'other_module/static/src/scss/core.scss', 'my_module/static/src/scss/override.scss'),
+    ('before',   'other_module/static/src/js/boot.js',    'my_module/static/src/js/pre_boot.js'),
+],
+```
+
+### Creating a Custom Bundle
+
+```python
+'assets': {
+    'my_module.assets_reports_custom': [
+        'my_module/static/src/js/custom_report.js',
+    ],
+}
+```
+
+Then reference it from a QWeb template with `<t t-call-assets="my_module.assets_reports_custom"/>`.
+
+### Static Description
+
+Odoo looks for `static/description/icon.png` automatically; no manifest entry
+needed. Additional screenshots go in `images`:
+
+```python
+'images': [
+    'static/description/banner.png',
+    'static/description/screenshot_1.png',
+],
+```
+
+---
+
+## External Dependencies
+
+### `external_dependencies`
+
+```python
+'external_dependencies': {
+    'python': [
+        'requests',
+        'pyjwt',
+        'python-dateutil',
+    ],
+    'bin': [
+        'wkhtmltopdf',
+        'ghostscript',
+    ],
+}
+```
+
+- `python`: Python package names (as importable / as listed in PyPI). Checked
+  via `pkg_resources.get_distribution`; falls back to `importlib.import_module`
+  (see `check_python_external_dependency`).
+- `bin`: Binaries that must be present on `PATH`.
+
+If a declared dependency is missing, the module refuses to install with an
+exception from `check_manifest_dependencies`.
+
+---
+
+## Hooks
+
+### Manifest Entries
+
+```python
+'pre_init_hook':   'pre_init_hook',
+'post_init_hook':  'post_init_hook',
+'uninstall_hook':  'uninstall_hook',
+'post_load':       'post_load',
+```
+
+Each value is a function name to look up inside the module's `__init__.py`
+(technically `sys.modules['odoo.addons.<module_name>']`).
+
+### Signatures in Odoo 16
+
+Verified against `odoo/modules/loading.py` (lines ~194, 247, 565):
+
+```python
+# __init__.py
+from odoo import SUPERUSER_ID, api
+
+def pre_init_hook(cr):
+    """Runs before the module's models/data are loaded, on fresh install only."""
+    # Cursor-only entry point. Use SQL here, or build an Environment manually
+    # only if you really need ORM access.
+    ...
+
+def post_init_hook(cr, registry):
+    """Runs after install (after data load), on fresh install only."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    ...
+
+def uninstall_hook(cr, registry):
+    """Runs when the module is being removed."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    ...
+```
+
+In Odoo 16, `pre_init_hook` runs before installation with a cursor-only style
+entry point. `post_init_hook` and `uninstall_hook` are called with
+`(cr, registry)`. When a hook needs ORM access, create an Environment manually
+inside the hook:
+
+```python
+from odoo import SUPERUSER_ID, api
+
+env = api.Environment(cr, SUPERUSER_ID, {})
+```
+
+### `post_load`
+
+Different beast — runs **at module import time**, once per server process, not
+per database:
+
+```python
+def post_load():
+    # No arguments. Called exactly once per worker.
+    # Use for server-wide monkey-patching or global registration.
+    ...
+```
+
+Declared in `module.py` (`load_openerp_module`): `getattr(sys.modules[qualname], info['post_load'])()`.
+
+### Example `__init__.py`
+
+```python
+# my_module/__init__.py
+from odoo import SUPERUSER_ID, api
+
+from . import controllers
+from . import models
+from . import wizard
+
+
+def pre_init_hook(cr):
+    cr.execute("""
+        CREATE TABLE IF NOT EXISTS my_module_audit (
+            id SERIAL PRIMARY KEY,
+            message TEXT,
+            create_date TIMESTAMP DEFAULT NOW()
+        )
+    """)
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['ir.config_parameter'].sudo().set_param('my_module.enabled', 'True')
+    env['my.model'].create({'name': 'Default', 'code': 'DFLT'})
+
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    cr.execute("DROP TABLE IF EXISTS my_module_audit")
+    env['ir.config_parameter'].sudo().search([
+        ('key', '=like', 'my_module.%')
+    ]).unlink()
+```
+
+---
+
+## Other Fields
+
+### `application`
+
+```python
+'application': True,
+```
+
+Marks the module as an application. Applications appear in the **Apps** filter
+by default and get their own entry in the Apps category tree.
+
+### `installable`
+
+```python
+'installable': True,
+```
+
+Set to `False` to hide a module from the Apps list (useful for WIP or
+deprecated modules). The loader still parses the manifest.
+
+### `sequence`
+
+```python
+'sequence': 100,
+```
+
+Integer used to order modules within their category. Lower values appear first.
+Mainly cosmetic for the Apps list.
+
+### `countries` (metadata)
+
+```python
+'countries': ['vn', 'th'],
+```
+
+This key is used as metadata by localization modules and app listings, but it is
+not part of Odoo 16's core `_DEFAULT_MANIFEST`.
+
+### `images`
+
+```python
+'images': [
+    'static/description/banner.png',
+    'static/description/main_screenshot.png',
+],
+```
+
+Paths relative to the module root. Shown on the Apps store page.
+
+### `website`
+
+```python
+'website': 'https://example.com/my_module',
+```
+
+Module homepage (project page / documentation).
+
+---
+
+## Complete Example
+
+```python
+# -*- coding: utf-8 -*-
+{
+    # == Identification ==
+    'name': 'Business Trip Management',
+    'version': '16.0.1.0.0',
+    'summary': 'Plan business trips, track per-diems and expenses',
+    'description': """
+Business Trip Management
+========================
+Features:
+
+* Plan trips with itinerary, per-diem rates, and approvers.
+* Track expenses and link receipts.
+* Generate PDF reports per trip.
+* Email templates for approval and reimbursement.
+""",
+    'category': 'Human Resources/Expenses',
+    'author': 'UncleCat',
+    'maintainer': 'UncleCat',
+    'website': 'https://example.com/business_trip',
+    'license': 'LGPL-3',
+
+    # == Dependencies ==
+    'depends': [
+        'base',
+        'mail',
+        'hr',
+        'hr_expense',
+        'product',
+    ],
+    'auto_install': False,
+
+    # == Data (order matters) ==
+    'data': [
+        # Security first
+        'security/business_trip_groups.xml',
+        'security/ir_rule.xml',
+        'security/ir.model.access.csv',
+
+        # Reference data
+        'data/ir_sequence_data.xml',
+        'data/mail_template_data.xml',
+        'data/ir_cron_data.xml',
+
+        # Wizards
+        'wizard/business_trip_cancel_views.xml',
+
+        # Views
+        'views/business_trip_views.xml',
+        'views/business_trip_expense_views.xml',
+        'views/hr_employee_views.xml',
+
+        # Reports
+        'report/business_trip_report_templates.xml',
+        'report/business_trip_report_actions.xml',
+
+        # Menus (last)
+        'views/business_trip_menus.xml',
+    ],
+
+    # == Demo ==
+    'demo': [
+        'demo/business_trip_demo.xml',
+    ],
+
+    # == Assets ==
+    'assets': {
+        'web.assets_backend': [
+            'business_trip/static/src/scss/trip_form.scss',
+            'business_trip/static/src/js/**/*.js',
+            'business_trip/static/src/xml/**/*.xml',
+        ],
+        'web.assets_frontend': [
+            'business_trip/static/src/js/portal_trip.js',
+        ],
+        'web.report_assets_common': [
+            'business_trip/static/src/scss/report.scss',
+        ],
+    },
+
+    # == External requirements ==
+    'external_dependencies': {
+        'python': ['python-dateutil'],
+        'bin':    ['wkhtmltopdf'],
+    },
+
+    # == Hooks ==
+    'pre_init_hook':  'pre_init_hook',
+    'post_init_hook': 'post_init_hook',
+    'uninstall_hook': 'uninstall_hook',
+
+    # == Flags ==
+    'application': True,
+    'installable': True,
+    'sequence':    20,
+}
+```
+
+---
+
+## Common Patterns
+
+### Bridge / link module
+
+```python
+{
+    'name': 'Sale ↔ Stock Bridge',
+    'version': '16.0.1.0.0',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'category': 'Hidden',
+    'depends': ['sale', 'stock'],
+    'auto_install': True,     # or ['sale', 'stock']
+    'data': ['views/sale_order_views.xml'],
+    'installable': True,
+}
+```
+
+### Website / portal module
+
+```python
+{
+    'name': 'My Portal Pages',
+    'version': '16.0.1.0.0',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'depends': ['portal', 'website'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/portal_templates.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'my_portal/static/src/js/portal.js',
+            'my_portal/static/src/scss/portal.scss',
+        ],
+    },
+    'installable': True,
+}
+```
+
+### Theme module
+
+```python
+{
+    'name': 'Theme Acme',
+    'version': '16.0.1.0.0',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'category': 'Website/Theme',
+    'depends': ['website'],
+    'data': ['views/options.xml'],
+    'assets': {
+        'web._assets_primary_variables': [
+            'theme_acme/static/src/scss/primary_variables.scss',
+        ],
+        'web.assets_frontend': [
+            'theme_acme/static/src/scss/style.scss',
+        ],
+    },
+    'images': ['static/description/banner.png'],
+    'installable': True,
+}
+```
+
+### Module with `external_dependencies`
+
+```python
+{
+    'name': 'Acme REST Connector',
+    'version': '16.0.1.0.0',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'depends': ['base'],
+    'external_dependencies': {
+        'python': ['requests', 'pyjwt'],
+    },
+    'data': ['security/ir.model.access.csv', 'views/config_views.xml'],
+    'installable': True,
+}
+```
+
+---
+
+## Base Code Reference
+
+All behavior documented above is derived from the Odoo 16 source:
+
+- `odoo/modules/module.py` — `MANIFEST_NAMES`, `_DEFAULT_MANIFEST`,
+  `load_manifest`, `get_manifest`, `adapt_version`, `load_openerp_module`
+  (invokes `post_load`), `check_python_external_dependency`.
+- `odoo/modules/loading.py` — hook invocation sites for `pre_init_hook`
+  (line ~194), `post_init_hook` (line ~247), and `uninstall_hook`
+  (line ~565). In v16, `pre_init_hook` is cursor-only, while
+  `post_init_hook` and `uninstall_hook` receive `(cr, registry)`; create
+  `api.Environment(cr, SUPERUSER_ID, {})` inside the hook when ORM access is
+  needed.
+- `odoo/release.py` — `version_info = (16, 0, 0, FINAL, 0, '')`,
+  `major_version = '16.0'` (used by `adapt_version`).
+- `addons/web/__manifest__.py` — canonical bundle names in v16
+  (`web.assets_backend`, `web.assets_common`, `web.assets_frontend`,
+  `web.report_assets_common`, `web.assets_tests`, `web.qunit_suite_tests`, …).
+- `addons/sale/__manifest__.py`, `addons/mail/__manifest__.py` — real-world
+  manifests to cross-reference when unsure about a field.

--- a/skills/odoo-16.0/references/odoo-16-migration-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-migration-guide.md
@@ -1,0 +1,721 @@
+---
+name: odoo-16-migration
+description: Migration scripts for Odoo 16 modules — folder layout migrations/16.0.X.Y.Z/{pre,post,end}-*.py, migrate(cr, version) signature, raw SQL patterns, idempotency, field rename / type change / model rename, recomputing stored computes, and util helpers from odoo.upgrade (odoo-upgrade-util).
+globs: "**/migrations/**/*.py"
+topics:
+  - Migration script discovery and execution in Odoo 16
+  - migrate(cr, installed_version) signature
+  - Folder layout `migrations/16.0.X.Y.Z/{pre,post,end}-*.py`
+  - The special 0.0.0 folder (any-version change)
+  - Raw SQL patterns and when to use ORM
+  - Idempotency (IF NOT EXISTS, ON CONFLICT, existence checks)
+  - Renaming a field / changing its type / renaming a model
+  - Recomputing stored compute fields
+  - `odoo.upgrade` / `odoo-upgrade-util` helpers
+  - Module lifecycle hooks vs migration scripts
+when_to_use:
+  - Shipping a new version of an Odoo 16 module
+  - Renaming fields, models, or tables
+  - Backfilling data during upgrades
+  - Recovering from a broken schema transition
+---
+
+# Odoo 16 Migration Guide
+
+Comprehensive guide to writing migration scripts for Odoo 16 modules. Covers
+folder layout, the `migrate()` signature, stage execution order, idempotent
+SQL patterns, schema evolution recipes, and integration with the
+`odoo.upgrade` / `odoo-upgrade-util` helper library.
+
+For module structure and hooks overview see
+[`odoo-16-development-guide.md`](./odoo-16-development-guide.md). For manifest
+field semantics see [`odoo-16-manifest-guide.md`](./odoo-16-manifest-guide.md).
+
+## Table of Contents
+
+1. [When Migrations Run](#when-migrations-run)
+2. [Folder Layout](#folder-layout)
+3. [`migrate(cr, version)` Signature](#migratecr-version-signature)
+4. [Stages: `pre-`, `post-`, `end-`](#stages-pre--post--end-)
+5. [The Special `0.0.0` Folder](#the-special-000-folder)
+6. [Module Lifecycle Hooks vs Migrations](#module-lifecycle-hooks-vs-migrations)
+7. [Raw SQL Patterns](#raw-sql-patterns)
+8. [Idempotency](#idempotency)
+9. [Recipes](#recipes)
+    - [Rename a field](#rename-a-field)
+    - [Change a field type](#change-a-field-type)
+    - [Rename a model (and its table)](#rename-a-model-and-its-table)
+    - [Drop an obsolete field/model](#drop-an-obsolete-fieldmodel)
+    - [Recompute a stored compute](#recompute-a-stored-compute)
+    - [Batched data backfill](#batched-data-backfill)
+10. [`odoo.upgrade` / `odoo-upgrade-util`](#odooupgrade--odoo-upgrade-util)
+11. [Testing Migrations](#testing-migrations)
+12. [Version Management](#version-management)
+13. [Base Code Reference](#base-code-reference)
+
+---
+
+## When Migrations Run
+
+Migration scripts run when `--update=<module>` (or `-u`) is invoked **and**
+the installed module version (from `ir_module_module.latest_version`) is
+strictly less than the manifest version.
+
+The loader walks every version folder and runs only the ones where:
+
+```
+installed_version < version_folder <= manifest_version
+```
+
+Fresh installs (`installed_version is None`) **skip** migrations entirely —
+use `post_init_hook` for initial data in that case.
+
+The dispatcher is `odoo.modules.migration.MigrationManager.migrate_module`.
+
+---
+
+## Folder Layout
+
+```
+my_module/
+├── __manifest__.py                  # 'version': '16.0.1.2.0'
+├── migrations/
+│   ├── 16.0.1.0.0/
+│   │   ├── pre-migrate.py           # before schema sync
+│   │   ├── post-migrate_data.py     # after schema sync
+│   │   └── end-cleanup.py           # after ALL modules updated
+│   ├── 16.0.1.1.0/
+│   │   └── post-rename_fields.py
+│   ├── 16.0.1.2.0/
+│   │   ├── pre-fix_constraint.py
+│   │   └── post-backfill.py
+│   ├── 0.0.0/                       # runs on every version change
+│   │   ├── pre-always.py
+│   │   └── end-always.py
+│   └── tests/                       # ignored by the dispatcher
+│       └── test_17_0_1_1_0.py
+└── upgrades/                        # optional alternative root
+    └── 16.0.1.1.0/
+        └── pre-migrate.py
+```
+
+Rules:
+
+1. Folder name must match the regex in `odoo/modules/migration.py:VERSION_RE`.
+   Accepted shapes: `x.y`, `x.y.z`, `16.0.x.y`, `16.0.x.y.z`, and the literal
+   `0.0.0`. A folder named `tests` is ignored.
+2. Scripts are `.py` files whose basename **starts with** `pre-`, `post-`, or
+   `end-`. Everything after the prefix is free-form (typically a short
+   description).
+3. Both `module/migrations/` and `module/upgrades/` are scanned (same script
+   discovery).
+4. The version folder is compared against the module's manifest version after
+   being normalized via `convert_version` (prepending `16.0.` when needed).
+
+---
+
+## `migrate(cr, version)` Signature
+
+Every migration script **must** expose a module-level function named
+`migrate` with this signature:
+
+```python
+# migrations/16.0.1.1.0/post-migrate_rename.py
+
+def migrate(cr, version):
+    """
+    cr:      odoo.sql_db.Cursor — raw DB cursor. NO environment.
+    version: str or None — the previously installed version, e.g. '16.0.1.0.0'.
+             None means fresh install (migrations do not run in that case
+             anyway, but the contract allows checking).
+    """
+    if version is None:
+        return
+    cr.execute("UPDATE my_model SET state = 'confirmed' WHERE state = 'validated'")
+```
+
+Accepted parameter name variants (use underscore prefix for unused ones):
+
+```python
+def migrate(cr, version): ...
+def migrate(cr, _version): ...     # version not read
+def migrate(_cr, version): ...     # rare
+def migrate(_cr, _version): ...    # rare
+```
+
+The dispatcher calls `mod.migrate(cr, installed_version)` — a missing `migrate`
+function logs an error and skips the file (see
+`odoo/modules/migration.py:exec_script`).
+
+### Getting an ORM Environment inside a script
+
+`migrate()` only receives a cursor. To use the ORM:
+
+```python
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # now: env['res.partner'], env.ref('my_module.foo'), ...
+```
+
+Caveats:
+
+- In `pre-` scripts, **models of the module being upgraded are not yet
+  reloaded** — ORM access is safe for *other* already-loaded models but may
+  see stale schema for the current module.
+- In `post-` scripts, models are fully loaded. This is the best place for ORM
+  work.
+
+---
+
+## Stages: `pre-`, `post-`, `end-`
+
+For a given module upgrade, the loader executes migration scripts in this
+order (see `odoo/modules/loading.py`):
+
+```
+For each module being upgraded:
+  1. pre-*.py   ← before schema sync (tables may lack new columns)
+  2. <schema sync>
+  3. Load data files (XML/CSV)
+  4. post-*.py  ← after schema sync, models are fully loaded
+
+After ALL modules have been upgraded:
+  5. end-*.py   ← cross-module invariants
+```
+
+### `pre-` scripts
+
+- Tables/columns declared by the **current** new manifest may not yet exist.
+- The old schema is still in place.
+- Best for:
+  - Renaming columns/tables BEFORE Odoo's ORM creates new ones.
+  - Converting column types to avoid destructive auto-migrations.
+  - Dropping obsolete columns/tables so the ORM doesn't complain.
+  - Pre-computing data that the new schema sync will consume.
+
+### `post-` scripts
+
+- Schema is up to date, data files (XML/CSV) have been loaded.
+- Models from the current module are usable via the ORM.
+- Best for:
+  - Backfilling new fields.
+  - Data transformations that need high-level ORM features.
+  - Recomputing stored compute fields.
+
+### `end-` scripts
+
+- Run **after all modules** are upgraded.
+- Use for cross-module consistency fixes: e.g. you need models from another
+  module whose migration also runs in this batch.
+
+---
+
+## The Special `0.0.0` Folder
+
+Scripts in `migrations/0.0.0/` run **on every version change** of the module
+(any bump). Execution order relative to other folders (per
+`odoo/modules/migration.py:_get_migration_versions`):
+
+- `pre` stage: `0.0.0/pre-*.py` runs **FIRST** (before any versioned
+  `pre-*.py`).
+- `post` stage: `0.0.0/post-*.py` runs **LAST**.
+- `end` stage: `0.0.0/end-*.py` runs **LAST**.
+
+Use sparingly. Typical use cases:
+
+- Always-run sanity checks.
+- Drop a legacy column that may linger from any prior version.
+- Emit log markers during every upgrade.
+
+---
+
+## Module Lifecycle Hooks vs Migrations
+
+| | Manifest hook | Migration script |
+|---|---------------|------------------|
+| Declared in | `__manifest__.py` → `pre_init_hook` / `post_init_hook` / `uninstall_hook` | `migrations/<ver>/{pre,post,end}-*.py` |
+| Runs on | Fresh install (hooks) or uninstall. | Module upgrade (version bump). |
+| Fresh install | ✅ Runs. | ❌ Does not run. |
+| Upgrade | ❌ Does not run. | ✅ Runs (stages `pre`, `post`, `end`). |
+| Signature | `hook(env)` (v16). | `migrate(cr, version)`. |
+
+**Rule of thumb:** code that should run once per database (initial data,
+default config) goes in `post_init_hook`; code that fixes data from a prior
+version goes in a migration script.
+
+---
+
+## Raw SQL Patterns
+
+### Why SQL (often) beats ORM in migrations
+
+- 10–100× faster for bulk updates (no Python per-record overhead).
+- Does not trigger `compute`, `tracking`, `_log_access`, email notifications,
+  or `ir.rule` filters — which is usually what you want during an upgrade.
+- Schema operations (ALTER TABLE) have to be SQL.
+
+### Cursor API quick reference
+
+```python
+def migrate(cr, version):
+    # Parameterize everything that is not a static SQL token.
+    cr.execute("UPDATE my_model SET state = %s WHERE state = %s",
+               ('confirmed', 'validated'))
+
+    # Fetch values after a SELECT.
+    cr.execute("SELECT id, name FROM my_model WHERE state = 'draft'")
+    for row_id, name in cr.fetchall():
+        ...
+
+    # Multiple rows in one statement.
+    cr.executemany(
+        "INSERT INTO my_log (record_id, message) VALUES (%s, %s)",
+        [(1, 'hello'), (2, 'world')],
+    )
+
+    # Commit is NOT needed — the outer transaction is managed by Odoo.
+    # Use cr.commit() only for long migrations where you want to checkpoint.
+```
+
+### Useful SQL skeletons
+
+```sql
+-- Add a column safely
+ALTER TABLE my_model ADD COLUMN IF NOT EXISTS new_field VARCHAR;
+
+-- Drop a column safely
+ALTER TABLE my_model DROP COLUMN IF EXISTS old_field;
+
+-- Rename a column (PostgreSQL)
+ALTER TABLE my_model RENAME COLUMN old_name TO new_name;
+
+-- Change a column type with explicit cast
+ALTER TABLE my_model
+    ALTER COLUMN amount TYPE NUMERIC USING amount::NUMERIC;
+
+-- Upsert
+INSERT INTO ir_config_parameter (key, value)
+VALUES ('my_module.version', '16.0.1.1.0')
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+```
+
+---
+
+## Idempotency
+
+Migration scripts must be **safe to re-run**. Odoo does not guarantee
+exactly-once execution (DBs can be replayed, upgrades can be re-triggered
+after a crash). Patterns:
+
+```python
+def migrate(cr, version):
+    # 1. Guard DDL with IF (NOT) EXISTS
+    cr.execute("ALTER TABLE my_model ADD COLUMN IF NOT EXISTS new_field VARCHAR")
+
+    # 2. Guard DML with a predicate that becomes false after the first run
+    cr.execute("""
+        UPDATE my_model
+           SET new_field = old_field
+         WHERE new_field IS NULL
+           AND old_field IS NOT NULL
+    """)
+
+    # 3. Check existence before acting
+    cr.execute("""
+        SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'my_model' AND column_name = 'legacy_field'
+    """)
+    if cr.fetchone():
+        cr.execute("ALTER TABLE my_model DROP COLUMN legacy_field")
+
+    # 4. Use ON CONFLICT for inserts
+    cr.execute("""
+        INSERT INTO ir_config_parameter (key, value)
+        VALUES (%s, %s)
+        ON CONFLICT (key) DO NOTHING
+    """, ('my_module.feature_x', 'enabled'))
+```
+
+---
+
+## Recipes
+
+### Rename a field
+
+Rename in `pre-` so the ORM's schema sync does not create an empty new column
+alongside:
+
+```python
+# migrations/16.0.1.1.0/pre-rename_customer.py
+
+def migrate(cr, version):
+    # Only rename if the old column still exists and the new one doesn't.
+    cr.execute("""
+        SELECT
+            (SELECT 1 FROM information_schema.columns
+              WHERE table_name='sale_order' AND column_name='customer_id') AS old_col,
+            (SELECT 1 FROM information_schema.columns
+              WHERE table_name='sale_order' AND column_name='partner_id') AS new_col
+    """)
+    old_col, new_col = cr.fetchone()
+    if old_col and not new_col:
+        cr.execute("ALTER TABLE sale_order RENAME COLUMN customer_id TO partner_id")
+
+    # Also rename the metadata so audit logs stay consistent.
+    cr.execute("""
+        UPDATE ir_model_fields
+           SET name = 'partner_id'
+         WHERE model = 'sale.order' AND name = 'customer_id'
+    """)
+    cr.execute("""
+        UPDATE ir_translation
+           SET name = REPLACE(name, ',customer_id', ',partner_id')
+         WHERE name LIKE 'sale.order,customer_id'
+    """)
+```
+
+If the field is declared with `oldname=` in v16, the ORM handles the rename
+for you — but writing an explicit migration is more robust.
+
+### Change a field type
+
+```python
+# migrations/16.0.1.1.0/pre-change_amount_type.py
+
+def migrate(cr, version):
+    # amount: Integer -> Float. USING clause forces the cast.
+    cr.execute("""
+        ALTER TABLE my_model
+        ALTER COLUMN amount TYPE DOUBLE PRECISION
+        USING amount::DOUBLE PRECISION
+    """)
+```
+
+If the conversion can fail (Char → Integer with non-numeric rows), materialize
+a temporary column, backfill, then swap:
+
+```python
+def migrate(cr, version):
+    cr.execute("ALTER TABLE my_model ADD COLUMN IF NOT EXISTS amount_int INTEGER")
+    cr.execute("""
+        UPDATE my_model
+           SET amount_int = CASE
+               WHEN amount ~ '^[0-9]+$' THEN amount::INTEGER
+               ELSE 0
+           END
+    """)
+    cr.execute("ALTER TABLE my_model DROP COLUMN amount")
+    cr.execute("ALTER TABLE my_model RENAME COLUMN amount_int TO amount")
+```
+
+### Rename a model (and its table)
+
+```python
+# migrations/16.0.1.1.0/pre-rename_model.py
+
+def migrate(cr, version):
+    # 1. Table
+    cr.execute("ALTER TABLE IF EXISTS old_model RENAME TO new_model")
+
+    # 2. ir_model
+    cr.execute("""
+        UPDATE ir_model SET model = 'new.model' WHERE model = 'old.model'
+    """)
+
+    # 3. ir_model_fields references
+    cr.execute("""
+        UPDATE ir_model_fields SET model = 'new.model' WHERE model = 'old.model'
+    """)
+    cr.execute("""
+        UPDATE ir_model_fields SET relation = 'new.model' WHERE relation = 'old.model'
+    """)
+
+    # 4. ir_model_data XML IDs
+    cr.execute("""
+        UPDATE ir_model_data SET model = 'new.model' WHERE model = 'old.model'
+    """)
+
+    # 5. ir_attachment
+    cr.execute("""
+        UPDATE ir_attachment SET res_model = 'new.model' WHERE res_model = 'old.model'
+    """)
+
+    # 6. mail tables that reference the model name
+    for table in ('mail_followers', 'mail_message', 'mail_activity'):
+        cr.execute(f"""
+            UPDATE {table} SET res_model = 'new.model' WHERE res_model = 'old.model'
+        """)
+
+    # 7. ir_act_window.res_model, binding_model_id references, etc. as applicable
+    cr.execute("""
+        UPDATE ir_act_window SET res_model = 'new.model' WHERE res_model = 'old.model'
+    """)
+```
+
+The `odoo.upgrade.util` helper `rename_model` (see next section) bundles all
+these steps.
+
+### Drop an obsolete field/model
+
+```python
+# migrations/16.0.2.0.0/pre-drop_legacy.py
+
+def migrate(cr, version):
+    cr.execute("ALTER TABLE my_model DROP COLUMN IF EXISTS legacy_ref")
+    cr.execute("DELETE FROM ir_model_fields WHERE model='my.model' AND name='legacy_ref'")
+    cr.execute("DELETE FROM ir_model_data WHERE model='my.model' AND name LIKE 'legacy_%'")
+```
+
+### Recompute a stored compute
+
+When a new version changes the formula of a stored computed field, run the
+recompute in `post-`:
+
+```python
+# migrations/16.0.1.1.0/post-recompute_margin.py
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    SaleOrder = env['sale.order']
+    # Mark the field for recomputation, then flush.
+    orders = SaleOrder.search([])
+    SaleOrder.invalidate_model(['margin'])
+    orders._compute_margin()
+    orders.flush_model(['margin'])
+```
+
+Alternatively, mark fields for lazy recomputation via `ir_attachment`-like
+SQL trick:
+
+```python
+def migrate(cr, version):
+    # Force re-init by clearing the stored values; compute will re-run on read.
+    cr.execute("UPDATE sale_order SET margin = NULL")
+```
+
+### Batched data backfill
+
+For very large tables, commit in batches to avoid long locks and huge
+transactions:
+
+```python
+def migrate(cr, version):
+    BATCH = 5000
+    offset = 0
+    while True:
+        cr.execute("""
+            WITH batch AS (
+                SELECT id FROM my_model
+                 WHERE new_field IS NULL
+                 ORDER BY id
+                 LIMIT %s OFFSET %s
+            )
+            UPDATE my_model m
+               SET new_field = LOWER(m.old_field)
+              FROM batch
+             WHERE m.id = batch.id
+            RETURNING m.id
+        """, (BATCH, offset))
+        rows = cr.fetchall()
+        if not rows:
+            break
+        cr.commit()
+        offset += BATCH
+```
+
+---
+
+## `odoo.upgrade` / `odoo-upgrade-util`
+
+Odoo 16 exposes an `odoo.upgrade` namespace (see
+`odoo/modules/module.py:initialize_sys_path`). The namespace is populated
+from:
+
+- `--upgrade-path` CLI option (server config), or
+- the legacy `odoo/addons/base/maintenance/migrations/` path.
+
+The standard helper library loaded there is **`odoo-upgrade-util`** (the same
+library Odoo S.A. uses in its enterprise upgrade service; distributed as a
+separate repository). When installed, you can import it from any migration
+script:
+
+```python
+from odoo.upgrade import util
+
+
+def migrate(cr, version):
+    util.rename_field(cr, 'sale.order', 'old_field', 'new_field')
+    util.remove_field(cr, 'sale.order', 'deprecated_field')
+    util.rename_model(cr, 'old.model', 'new.model')
+    util.remove_model(cr, 'old.model')
+    util.recompute_fields(cr, 'sale.order', ['margin'])
+    util.merge_groups(cr, ['base.group_old'], 'base.group_new')
+    util.force_install_module(cr, 'new_dependency')
+```
+
+Commonly used helpers (all live in `odoo.upgrade.util`):
+
+| Helper | Purpose |
+|--------|---------|
+| `rename_field(cr, model, old, new)` | Rename a field + all metadata. |
+| `rename_model(cr, old, new)` | Rename a model + update every reference. |
+| `rename_module(cr, old, new)` | Rename a whole module. |
+| `rename_xmlid(cr, old_xmlid, new_xmlid)` | Move a record's `ir.model.data` entry. |
+| `remove_field(cr, model, name)` | Drop a field + metadata + column. |
+| `remove_model(cr, model)` | Drop a model, its table, all references. |
+| `remove_record(cr, xmlid)` | Delete a record and its `ir.model.data` row. |
+| `recompute_fields(cr, model, fields)` | Re-queue stored computes. |
+| `invalidate(cr, model)` | Invalidate cache for a model. |
+| `force_install_module(cr, name)` | Flip a module to `to install` during upgrade. |
+| `module_installed(cr, name)` | Check install state. |
+| `ENVIRON` / `env(cr)` | Shortcut to build an `api.Environment`. |
+| `explode_query`, `chunks` | Split big queries/IN lists for batching. |
+
+Availability: the helpers are **not** shipped inside the Odoo 16 community
+repo — you install `odoo-upgrade-util` alongside (either by placing the repo
+on `--upgrade-path` or by installing the Python package). If the library is
+not present, `from odoo.upgrade import util` raises `ImportError`; write
+scripts that either require it explicitly or fall back to raw SQL.
+
+Fallback-friendly pattern:
+
+```python
+try:
+    from odoo.upgrade import util
+except ImportError:
+    util = None
+
+
+def migrate(cr, version):
+    if util is not None:
+        util.rename_field(cr, 'sale.order', 'old_f', 'new_f')
+        return
+
+    # Manual fallback
+    cr.execute("ALTER TABLE sale_order RENAME COLUMN old_f TO new_f")
+    cr.execute("UPDATE ir_model_fields SET name='new_f' "
+               "WHERE model='sale.order' AND name='old_f'")
+```
+
+---
+
+## Testing Migrations
+
+Odoo 16 does not ship an `upgrade_code` CLI (that tool was added in v18+).
+Instead, test migrations by re-running the upgrade locally:
+
+```bash
+# 1. Install the OLD version on a scratch DB
+./odoo-bin -d test_upgrade --init=my_module --stop-after-init
+
+# 2. Replace the code on disk with the NEW version (git checkout).
+
+# 3. Run the upgrade and capture logs.
+./odoo-bin -d test_upgrade \
+           --update=my_module \
+           --log-level=debug \
+           --log-handler=odoo.modules.migration:DEBUG \
+           --stop-after-init
+```
+
+### Unit-testing a migration script
+
+Scripts are plain Python. Import and call `migrate()` with a mocked cursor
+from a regular Odoo test — this lets you assert on the emitted SQL:
+
+```python
+# tests/test_migration_17_0_1_1_0.py
+from unittest.mock import MagicMock
+
+from odoo.tests.common import TransactionCase
+
+# Migration scripts are not standard importable modules; load via importlib.
+import importlib.util, pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    'pre_rename',
+    pathlib.Path(__file__).parents[1] / 'migrations/16.0.1.1.0/pre-rename_customer.py',
+)
+_mod = importlib.util.module_from_spec(_spec); _spec.loader.exec_module(_mod)
+
+
+class TestMigrationRename(TransactionCase):
+    def test_idempotent(self):
+        # Running twice must not raise.
+        _mod.migrate(self.cr, '16.0.1.0.0')
+        _mod.migrate(self.cr, '16.0.1.0.0')
+```
+
+---
+
+## Version Management
+
+### Bumping the manifest
+
+Always bump `version` in `__manifest__.py` before the migration folder you
+want to trigger:
+
+```python
+# __manifest__.py
+'version': '16.0.1.1.0',   # <-- activates migrations/16.0.1.1.0/*
+```
+
+The rule (from `MigrationManager.migrate_module`):
+
+```
+installed_version < convert_version(folder_name) <= manifest_version
+```
+
+`convert_version` prepends `16.0.` when the folder name has only 2–3
+components.
+
+### Comparing versions inside a script
+
+```python
+from odoo.tools.parse_version import parse_version
+
+
+def migrate(cr, version):
+    if version is None:
+        return
+
+    if parse_version(version) < parse_version('16.0.1.0.0'):
+        # migrating from a pre-1.0 internal release
+        cr.execute("UPDATE my_model SET state='draft' WHERE state IS NULL")
+
+    if parse_version(version) < parse_version('16.0.1.1.0'):
+        cr.execute("ALTER TABLE my_model ADD COLUMN IF NOT EXISTS note TEXT")
+```
+
+Note: the version folder name already gates execution. Compare only when you
+need to split logic inside a single script.
+
+---
+
+## Base Code Reference
+
+- `odoo/modules/migration.py` — migration dispatcher:
+  - `VERSION_RE` (accepted folder names).
+  - `MigrationManager.migrate_module(pkg, stage)` (stage ∈ `pre`, `post`,
+    `end`).
+  - `_get_migration_versions` (handles the `0.0.0` reordering).
+  - `exec_script` — loads the `.py`, calls `migrate(cr, installed_version)`,
+    raises `AttributeError` if `migrate` is missing.
+- `odoo/modules/loading.py` — the orchestrator that calls
+  `migrations.migrate_module(package, 'pre')` (before data load) and
+  `migrations.migrate_module(package, 'post')` (after data load). `end-*.py`
+  scripts run after all modules have been processed.
+- `odoo/modules/module.py` — `initialize_sys_path` wires `odoo.upgrade` to the
+  `--upgrade-path` directory (enabling `from odoo.upgrade import util`).
+  `adapt_version` normalizes `x.y(.z)` to `16.0.x.y(.z)`.
+- `odoo/tools/parse_version.py` — `parse_version()` for intra-script
+  comparisons.
+- `odoo/release.py` — `version_info = (16, 0, 0, FINAL, 0, '')`,
+  `major_version = '16.0'`.
+- External: [`odoo-upgrade-util`](https://github.com/odoo/upgrade-util) — the
+  Odoo-maintained helper library loaded via the `odoo.upgrade` namespace.

--- a/skills/odoo-16.0/references/odoo-16-mixins-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-mixins-guide.md
@@ -1,0 +1,792 @@
+---
+name: odoo-16-mixins
+description: Complete reference for Odoo 16 mixins and useful classes. Covers mail.thread (messaging, chatter, field tracking), mail.activity.mixin (activities), mail.alias.mixin (email aliases), utm.mixin (campaign tracking), portal.mixin (customer portal access), image.mixin / avatar.mixin (images and avatars) and rating.mixin (customer ratings).
+globs: "**/models/**/*.py"
+topics:
+  - mail.thread (messaging, chatter, followers, tracking)
+  - mail.activity.mixin (activities)
+  - mail.alias.mixin (email aliases)
+  - utm.mixin (campaign tracking)
+  - portal.mixin (customer portal access)
+  - image.mixin and avatar.mixin (image/avatar)
+  - rating.mixin (customer ratings)
+when_to_use:
+  - Adding messaging/chatter to models
+  - Setting up email aliases
+  - Adding activities to models
+  - Tracking marketing campaigns
+  - Exposing records to customer portal
+  - Adding images or avatars to records
+  - Implementing customer ratings
+---
+
+# Odoo 16 Mixins Guide
+
+Complete reference for Odoo 16 mixins: messaging, activities, email aliases, tracking, portal, image/avatar and ratings.
+
+## Table of Contents
+
+1. [mail.thread - Messaging](#mailthread---messaging)
+2. [mail.activity.mixin - Activities](#mailactivitymixin---activities)
+3. [mail.alias.mixin - Email Aliases](#mailaliasmixin---email-aliases)
+4. [utm.mixin - Campaign Tracking](#utmmixin---campaign-tracking)
+5. [portal.mixin - Customer Portal](#portalmixin---customer-portal)
+6. [image.mixin / avatar.mixin - Images and Avatars](#imagemixin--avatarmixin---images-and-avatars)
+7. [rating.mixin - Customer Ratings](#ratingmixin---customer-ratings)
+8. [Mixin Composition](#mixin-composition)
+
+---
+
+## mail.thread - Messaging
+
+### Basic Integration
+
+The `mail.thread` mixin provides chatter, followers, messages, and field tracking.
+
+```python
+from odoo import models, fields
+
+
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+    _inherit = ['mail.thread']
+    _description = 'Business Trip'
+
+    name = fields.Char(required=True, tracking=True)
+    partner_id = fields.Many2one('res.partner', string='Responsible', tracking=True)
+    state = fields.Selection(
+        [('draft', 'Draft'), ('confirmed', 'Confirmed'), ('done', 'Done')],
+        default='draft', tracking=True,
+    )
+    note = fields.Html()
+```
+
+### Form View Integration (Odoo 16)
+
+Odoo 16 uses the classic `div.oe_chatter` structure (the `<chatter>` shortcut tag was introduced in Odoo 18).
+
+```xml
+<record id="business_trip_form" model="ir.ui.view">
+    <field name="name">business.trip.form</field>
+    <field name="model">business.trip</field>
+    <field name="arch" type="xml">
+        <form string="Business Trip">
+            <sheet>
+                <group>
+                    <field name="name"/>
+                    <field name="partner_id"/>
+                    <field name="state"/>
+                </group>
+            </sheet>
+            <div class="oe_chatter">
+                <field name="message_follower_ids"/>
+                <field name="activity_ids"/>
+                <field name="message_ids"/>
+            </div>
+        </form>
+    </field>
+</record>
+```
+
+### Fields Added by mail.thread
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message_follower_ids` | One2many | Followers of the record |
+| `message_partner_ids` | Many2many | Followers expressed as partners |
+| `message_ids` | One2many | Posted messages |
+| `message_is_follower` | Boolean | Is current user a follower? |
+| `message_has_error` | Boolean | Any failed notifications? |
+| `message_attachment_count` | Integer | Attachment count |
+| `message_main_attachment_id` | Many2one | Main attachment |
+
+### Field Tracking
+
+Add `tracking=True` to log changes in the chatter automatically. Passing an integer sets the display order in the tracking table.
+
+```python
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+    _inherit = ['mail.thread']
+
+    name = fields.Char(tracking=True)
+    # tracking with explicit order (smaller integer = appears first)
+    state = fields.Selection([...], tracking=10)
+    partner_id = fields.Many2one('res.partner', tracking=20)
+    amount = fields.Monetary(tracking=30)
+```
+
+Any change to a tracked field is automatically logged in the chatter with the old and new values.
+
+### Controlling Messaging Access: `_mail_post_access`
+
+The model attribute `_mail_post_access` controls which ACL operation is required to post a message. Default is `'write'`.
+
+```python
+class PublicThread(models.Model):
+    _name = 'public.thread'
+    _inherit = ['mail.thread']
+
+    # Anyone with read access can post a message
+    _mail_post_access = 'read'
+```
+
+Valid values: `'read'`, `'write'`, `'create'`, `'unlink'`.
+
+### Posting Messages
+
+#### message_post() - Main API
+
+```python
+def notify_confirmation(self):
+    self.ensure_one()
+    self.message_post(
+        body='Trip has been confirmed!',
+        subject='Trip Confirmation',
+        message_type='comment',              # 'comment', 'notification', 'email'
+        subtype_xmlid='mail.mt_comment',     # or 'mail.mt_note' for internal log
+        partner_ids=[self.partner_id.id],    # extra recipients (list of IDs)
+        author_id=self.env.user.partner_id.id,
+    )
+```
+
+Key keyword arguments (all keyword-only in v16):
+
+| Argument | Description |
+|----------|-------------|
+| `body` | `str` (auto-escaped) or `markupsafe.Markup` for HTML |
+| `subject` | Optional subject |
+| `message_type` | `'notification'` (default), `'comment'`, `'email'`; NOT `'user_notification'` |
+| `subtype_xmlid` | XML id of the subtype, e.g. `'mail.mt_comment'`, `'mail.mt_note'` |
+| `subtype_id` | Alternative to `subtype_xmlid` |
+| `partner_ids` | Extra partner IDs to notify (list of integers) |
+| `author_id` | Partner ID of the author |
+| `email_from` | Author email (used when author_id is unknown) |
+| `parent_id` | Parent message for threading |
+| `attachment_ids` | List of existing `ir.attachment` IDs |
+| `attachments` | List of `(name, content)` or `(name, content, info)` tuples |
+
+#### Posting with Markup (HTML)
+
+```python
+from markupsafe import Markup
+
+
+def notify_html(self):
+    body = Markup("<p>Status changed to <b>%s</b></p>") % self.state
+    self.message_post(body=body, subtype_xmlid='mail.mt_note')
+```
+
+Never build HTML via f-strings: use `Markup(...) % value` or `Markup(...).format(value=...)` so user content is escaped.
+
+#### Posting with Attachments
+
+```python
+def attach_report(self, pdf_content):
+    self.message_post(
+        body='Report attached',
+        attachments=[('report.pdf', pdf_content)],
+    )
+```
+
+#### Sending via a Template
+
+In Odoo 16 use `message_post_with_template()` to render an existing mail template into the posted message:
+
+```python
+def send_template(self):
+    self.message_post_with_template(
+        self.env.ref('my_module.email_template_trip_confirmation').id,
+        subtype_xmlid='mail.mt_comment',
+    )
+```
+
+### Followers Management
+
+```python
+# Add partners as followers
+record.message_subscribe(partner_ids=[partner1.id, partner2.id])
+
+# Add with a specific subtype
+record.message_subscribe(
+    partner_ids=[partner.id],
+    subtype_ids=[self.env.ref('mail.mt_comment').id],
+)
+
+# Remove
+record.message_unsubscribe(partner_ids=[partner.id])
+```
+
+### Subtypes and `_track_subtype`
+
+Subtypes classify notifications so users can filter what they receive.
+
+Define a subtype in XML:
+
+```xml
+<record id="mt_trip_confirmed" model="mail.message.subtype">
+    <field name="name">Trip Confirmed</field>
+    <field name="res_model">business.trip</field>
+    <field name="default" eval="True"/>
+    <field name="description">Business Trip confirmed!</field>
+</record>
+```
+
+Override `_track_subtype` to emit a custom subtype when a tracked field changes.
+
+**Important (Odoo 16)**: `_track_subtype` must return a `mail.message.subtype` **record** (or `False`), not an XML id string.
+
+```python
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+    _inherit = ['mail.thread']
+
+    state = fields.Selection(
+        [('draft', 'Draft'), ('confirmed', 'Confirmed')], tracking=True,
+    )
+
+    def _track_subtype(self, init_values):
+        self.ensure_one()
+        if 'state' in init_values and self.state == 'confirmed':
+            return self.env.ref('my_module.mt_trip_confirmed')
+        return super()._track_subtype(init_values)
+```
+
+### Context Keys for Control
+
+| Key | Effect |
+|-----|--------|
+| `mail_create_nosubscribe` | Don't subscribe author on create |
+| `mail_create_nolog` | Don't log `"<Document> created"` message |
+| `mail_notrack` | Skip field tracking |
+| `tracking_disable` | Disable all mail.thread features (tracking + logging + subscription) |
+| `mail_auto_delete` | Auto-delete notifications (default `True`) |
+| `mail_notify_force_send` | Send mails directly instead of queuing |
+
+```python
+self.env['business.trip'].with_context(
+    tracking_disable=True,
+).create({'name': 'Silent Trip'})
+```
+
+### Incoming Mail Hooks (when combined with alias)
+
+```python
+def message_new(self, msg_dict, custom_values=None):
+    """Create a record from an incoming email."""
+    defaults = {
+        'name': msg_dict.get('subject') or 'Incoming',
+        'email_from': msg_dict.get('from'),
+    }
+    if custom_values:
+        defaults.update(custom_values)
+    return super().message_new(msg_dict, defaults)
+
+
+def message_update(self, msg_dict, update_vals=None):
+    """Update an existing record from a reply."""
+    return super().message_update(msg_dict, update_vals)
+```
+
+---
+
+## mail.activity.mixin - Activities
+
+The `mail.activity.mixin` adds an `activity_ids` one2many and helper fields/methods to schedule tasks on records (calls, meetings, to-dos, etc.).
+
+### Integration
+
+```python
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _description = 'Business Trip'
+
+    name = fields.Char(required=True)
+```
+
+### Form View Integration
+
+```xml
+<div class="oe_chatter">
+    <field name="message_follower_ids"/>
+    <field name="activity_ids"/>
+    <field name="message_ids"/>
+</div>
+```
+
+### Kanban Integration
+
+```xml
+<kanban>
+    <field name="activity_ids"/>
+    <field name="activity_state"/>
+    <templates>
+        <t t-name="kanban-box">
+            <div>
+                <field name="name"/>
+                <div class="oe_kanban_bottom_right">
+                    <field name="activity_ids" widget="kanban_activity"/>
+                </div>
+            </div>
+        </t>
+    </templates>
+</kanban>
+```
+
+### Fields Added
+
+| Field | Description |
+|-------|-------------|
+| `activity_ids` | One2many on `mail.activity` |
+| `activity_state` | `'overdue'`, `'today'`, `'planned'` or `False` |
+| `activity_user_id` | Responsible of the next activity |
+| `activity_type_id` | Next activity type |
+| `activity_date_deadline` | Next deadline |
+| `my_activity_date_deadline` | Next deadline for the current user |
+| `activity_summary` | Summary of the next activity |
+
+### Scheduling Activities
+
+```python
+from datetime import date, timedelta
+
+
+def plan_review(self):
+    self.activity_schedule(
+        'mail.mail_activity_data_todo',
+        user_id=self.env.user.id,
+        summary='Review trip',
+        note='<p>Please review and approve</p>',
+        date_deadline=date.today() + timedelta(days=3),
+    )
+
+
+def mark_done(self):
+    self.activity_feedback(
+        ['mail.mail_activity_data_todo'],
+        feedback='Reviewed, looks good',
+    )
+```
+
+| Method | Description |
+|--------|-------------|
+| `activity_schedule(act_type_xmlid, date_deadline=None, summary='', note='', **kwargs)` | Create an activity |
+| `activity_reschedule(act_type_xmlids, date_deadline=None, new_user_id=None)` | Move/reassign activities |
+| `activity_feedback(act_type_xmlids, feedback=None)` | Mark activities as done |
+| `activity_unlink(act_type_xmlids)` | Remove activities without feedback |
+
+### Context Keys
+
+| Key | Effect |
+|-----|--------|
+| `mail_activity_automation_skip` | Skip automated activity generation/update |
+
+---
+
+## mail.alias.mixin - Email Aliases
+
+Aliases allow creating records by sending an email to a specific address.
+
+Odoo 16 exposes `mail.alias.mixin` for records that should own a `mail.alias`
+row through `_inherits`. Every record gets an alias, and you customize alias
+creation through `_get_alias_model_name()` and `_get_alias_values()`.
+
+### mail.alias.mixin (required alias, full integration)
+
+```python
+from odoo import models, fields
+
+
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+    _inherit = ['mail.thread', 'mail.alias.mixin']
+    _description = 'Business Trip'
+
+    name = fields.Char(required=True)
+    expense_ids = fields.One2many('business.expense', 'trip_id')
+
+    # alias_id is required through _inherits; useful related fields include:
+    #   alias_name, alias_defaults, alias_domain, alias_contact, ...
+
+    def _get_alias_model_name(self, vals):
+        return 'business.expense'
+
+    def _get_alias_values(self):
+        """Return the values used when creating the underlying alias."""
+        values = super()._get_alias_values()
+        if self.id:
+            values['alias_defaults'] = "{'trip_id': %d}" % self.id
+            values['alias_contact'] = 'followers'
+        return values
+```
+
+### Form View
+
+```xml
+<group string="Email Alias">
+    <field name="alias_name"/>
+    <field name="alias_domain" readonly="1"/>
+    <field name="alias_contact"/>
+    <field name="alias_defaults" invisible="1"/>
+</group>
+```
+
+### Alias Configuration Fields
+
+| Field | Description |
+|-------|-------------|
+| `alias_name` | Local part of the email (e.g. `jobs` for `jobs@example.com`) |
+| `alias_domain` | Domain name (related, read-only) |
+| `alias_defaults` | Python dict literal of default values applied to created records |
+| `alias_contact` | `'everyone'`, `'partners'`, `'followers'` |
+| `alias_force_thread_id` | Force incoming mails into this thread ID |
+| `alias_bounced_content` | Bounce reply body used when the alias rejects a message |
+
+### Writable Fields (mail.alias.mixin)
+
+Only these alias fields can be written through the mixin:
+
+```python
+ALIAS_WRITEABLE_FIELDS = [
+    'alias_name', 'alias_contact',
+    'alias_defaults', 'alias_bounced_content',
+]
+```
+
+---
+
+## utm.mixin - Campaign Tracking
+
+Track marketing campaigns through URL parameters.
+
+```python
+from odoo import models, fields
+
+
+class Lead(models.Model):
+    _name = 'crm.lead'
+    _inherit = ['utm.mixin']
+
+    name = fields.Char()
+```
+
+### Fields Added
+
+| Field | Type | Cookie |
+|-------|------|--------|
+| `campaign_id` | Many2one `utm.campaign` | `odoo_utm_campaign` |
+| `source_id` | Many2one `utm.source` | `odoo_utm_source` |
+| `medium_id` | Many2one `utm.medium` | `odoo_utm_medium` |
+
+### How It Works
+
+1. User clicks `https://myodoo.com/?utm_campaign=winter_sale&utm_source=google`
+2. `ir_http` stores the URL parameters in cookies
+3. `default_get` on the UTM mixin reads those cookies and populates the fields when a record is created (e.g. via a website form)
+
+### Adding Custom Tracking
+
+```python
+class MyModel(models.Model):
+    _name = 'my.model'
+    _inherit = ['utm.mixin']
+
+    my_source = fields.Many2one('utm.source', string='Custom Source')
+
+    @api.model
+    def tracking_fields(self):
+        """Must be called as self.env['utm.mixin'].tracking_fields()."""
+        result = super().tracking_fields()
+        result.append(('utm_my_source', 'my_source', 'odoo_utm_my_source'))
+        return result
+```
+
+---
+
+## portal.mixin - Customer Portal
+
+Expose records to external partners through the customer portal with a signed access URL.
+
+```python
+from odoo import models, fields
+
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+    _inherit = ['portal.mixin', 'mail.thread']
+
+    partner_id = fields.Many2one('res.partner', required=True)
+
+    def _compute_access_url(self):
+        super()._compute_access_url()
+        for order in self:
+            order.access_url = f'/my/orders/{order.id}'
+```
+
+### Fields Added
+
+| Field | Description |
+|-------|-------------|
+| `access_url` | Portal URL of the record (must be computed by the model) |
+| `access_token` | Signed token to access the record without login |
+| `access_warning` | Optional warning message shown on the portal |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `_portal_ensure_token()` | Generate/return the record's access token |
+| `_get_share_url(redirect=False, signup_partner=False, pid=None)` | Build the full share URL with token |
+| `_get_access_action(access_uid=None, force_website=False)` | Returns the action that opens the record for a portal user |
+| `_get_access_warning()` | Override to emit a custom warning shown on the portal page |
+
+### Building a Share Link
+
+```python
+def action_share(self):
+    self.ensure_one()
+    return {
+        'type': 'ir.actions.act_url',
+        'url': self._get_share_url(),
+        'target': 'new',
+    }
+```
+
+---
+
+## image.mixin / avatar.mixin - Images and Avatars
+
+### image.mixin
+
+Stores an image with automatically-resized variants (1920, 1024, 512, 256, 128).
+
+```python
+from odoo import models, fields
+
+
+class Product(models.Model):
+    _name = 'my.product'
+    _inherit = ['image.mixin']
+
+    name = fields.Char()
+```
+
+Fields added:
+
+| Field | Max Size |
+|-------|----------|
+| `image_1920` | 1920 px (base) |
+| `image_1024` | 1024 px (related, stored) |
+| `image_512` | 512 px (related, stored) |
+| `image_256` | 256 px (related, stored) |
+| `image_128` | 128 px (related, stored) |
+
+Form view usage:
+
+```xml
+<field name="image_1920" widget="image" options="{'preview_image': 'image_128'}"/>
+```
+
+### avatar.mixin
+
+Extends `image.mixin` with auto-generated SVG avatars (initial + colour) when no image is uploaded.
+
+```python
+class Team(models.Model):
+    _name = 'team'
+    _inherit = ['avatar.mixin']
+    _avatar_name_field = 'name'  # defaults to 'name'
+
+    name = fields.Char(required=True)
+```
+
+Fields added (on top of `image.mixin`):
+
+| Field | Description |
+|-------|-------------|
+| `avatar_1920..avatar_128` | Either the uploaded image or a generated SVG (initial letter on a seeded HSL background) |
+
+Override `_avatar_name_field` if the initial should come from another field, or `_avatar_get_placeholder_path()` for a custom fallback PNG.
+
+---
+
+## rating.mixin - Customer Ratings
+
+Receive and aggregate ratings (1-5) from customers. The mixin **inherits `mail.thread`** automatically - you do not need to add it again.
+
+```python
+from odoo import models, fields
+
+
+class ProjectTask(models.Model):
+    _name = 'project.task'
+    _inherit = ['rating.mixin']           # inherits mail.thread
+    _description = 'Task'
+
+    name = fields.Char()
+    user_id = fields.Many2one('res.users')
+    partner_id = fields.Many2one('res.partner')
+```
+
+### Fields Added
+
+| Field | Description |
+|-------|-------------|
+| `rating_ids` | All ratings on this record |
+| `rating_count` | Number of consumed ratings |
+| `rating_avg` | Average rating (out of 5) |
+| `rating_avg_text` | Text version (`'Dissatisfied'`, `'Okay'`, `'Satisfied'`) |
+| `rating_last_value` | Last rating value |
+| `rating_last_feedback` | Last rating text feedback |
+| `rating_last_image` | Smiley image for the last rating |
+| `rating_percentage_satisfaction` | % of ratings >= threshold |
+
+### Identifying the Rater and the Rated
+
+By default the mixin uses `partner_id` (customer) as the rater and `user_id` (assignee) as the person rated. Override if different:
+
+```python
+def _rating_get_partner(self):
+    """Partner giving the rating (customer)."""
+    return self.customer_id or super()._rating_get_partner()
+
+
+def _rating_get_rated_partner(self):
+    """Partner being rated (internal user)."""
+    return self.assignee_id.partner_id or super()._rating_get_rated_partner()
+```
+
+### Sending a Rating Request
+
+```python
+def send_rating_request(self):
+    self.ensure_one()
+    self.rating_send_request(
+        rating_template=self.env.ref('my_module.rating_request_email'),
+        reuse_rating=False,
+        force_send=True,
+    )
+```
+
+### Portal Rating Link
+
+```python
+def rating_portal_link(self, value):
+    """Build /rate/<token>/<value> URL."""
+    return f'/rate/{self.rating_get_access_token()}/{value}'
+```
+
+---
+
+## Mixin Composition
+
+Stack mixins in `_inherit` to compose behaviour. Order is usually bottom-up (more specific first), but the mail mixins tolerate any order.
+
+### Typical Document Model
+
+```python
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _description = 'Business Trip'
+
+    name = fields.Char(required=True, tracking=True)
+    state = fields.Selection(
+        [('draft', 'Draft'), ('confirmed', 'Confirmed'), ('done', 'Done')],
+        default='draft', tracking=True,
+    )
+```
+
+### Document + Alias + Activities
+
+```python
+class HelpdeskTeam(models.Model):
+    _name = 'helpdesk.team'
+    _inherit = ['mail.thread', 'mail.activity.mixin', 'mail.alias.mixin']
+```
+
+### Portal-Visible Document
+
+```python
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+    _inherit = ['portal.mixin', 'mail.thread', 'mail.activity.mixin']
+```
+
+### CRM-style Rated Document
+
+```python
+class Lead(models.Model):
+    _name = 'crm.lead'
+    _inherit = ['mail.thread', 'mail.activity.mixin', 'utm.mixin', 'rating.mixin']
+    # rating.mixin already brings mail.thread; listing it explicitly is fine.
+```
+
+### Visual Product with Avatar
+
+```python
+class Team(models.Model):
+    _name = 'team'
+    _inherit = ['avatar.mixin', 'mail.thread']
+```
+
+---
+
+## Quick Reference
+
+### Mixin Summary
+
+| Mixin | Purpose | Key Fields |
+|-------|---------|------------|
+| `mail.thread` | Messaging, followers, tracking | `message_ids`, `message_follower_ids` |
+| `mail.activity.mixin` | Activities | `activity_ids`, `activity_state` |
+| `mail.alias.mixin` | Required email alias | `alias_id`, `alias_name`, `alias_domain` |
+| `utm.mixin` | Marketing tracking | `campaign_id`, `source_id`, `medium_id` |
+| `portal.mixin` | Portal URL + token | `access_url`, `access_token` |
+| `image.mixin` | Image with variants | `image_1920/1024/512/256/128` |
+| `avatar.mixin` | Auto-generated avatars | `avatar_1920/1024/512/256/128` |
+| `rating.mixin` | Customer ratings (+ mail.thread) | `rating_ids`, `rating_avg` |
+
+### Messaging Cheatsheet
+
+```python
+# Post a note (internal log, only followers)
+self.message_post(body='Internal note', subtype_xmlid='mail.mt_note')
+
+# Post a public comment (sends emails)
+self.message_post(
+    body='Hello!',
+    subtype_xmlid='mail.mt_comment',
+    partner_ids=[partner.id],
+)
+
+# Subscribe someone
+self.message_subscribe(partner_ids=[partner.id])
+
+# Schedule an activity
+self.activity_schedule(
+    'mail.mail_activity_data_todo',
+    summary='Review',
+    user_id=self.env.user.id,
+)
+```
+
+---
+
+## Base Code Reference
+
+The guide is based on the Odoo 16 source tree. Reference files:
+
+| File | Contents |
+|------|----------|
+| `addons/mail/models/mail_thread.py` | `mail.thread`, `message_post`, `_track_subtype`, `_mail_post_access` |
+| `addons/mail/models/mail_activity_mixin.py` | `mail.activity.mixin` and activity helpers |
+| `addons/mail/models/mail_alias_mixin.py` | Required-alias mixin (`_inherits` on `mail.alias`) |
+| `addons/utm/models/utm_mixin.py` | UTM fields and cookie mapping |
+| `addons/portal/models/portal_mixin.py` | Portal URL + access token |
+| `odoo/addons/base/models/image_mixin.py` | Image variants |
+| `odoo/addons/base/models/avatar_mixin.py` | Generated SVG avatar |
+| `addons/rating/models/rating_mixin.py` | Rating statistics (inherits `mail.thread`) |
+
+**For more Odoo 16 guides, see [SKILL.md](../SKILL.md)**

--- a/skills/odoo-16.0/references/odoo-16-model-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-model-guide.md
@@ -1,0 +1,813 @@
+---
+name: odoo-16-model
+description: Complete reference for Odoo 16 ORM model methods, CRUD operations, domain syntax, and recordset handling. Use this guide when writing model methods, ORM queries, search operations, or working with recordsets.
+globs: "**/models/**/*.py"
+topics:
+  - Recordset basics (browse, exists, empty)
+  - Search methods (search, search_read, search_count, search + read)
+  - Aggregation methods (read_group public API, _read_group caveats)
+  - CRUD operations (create, read, write, unlink)
+  - Domain syntax (operators, logical, relational)
+  - Environment context (with_context, with_user, with_company)
+  - Recordset iteration patterns
+when_to_use:
+  - Writing ORM queries
+  - Performing CRUD operations
+  - Building domain filters
+  - Using read_group() for aggregations
+  - Iterating over recordsets
+  - Using environment context
+---
+
+# Odoo 16 Model Guide
+
+Complete reference for Odoo 16 ORM model methods, CRUD operations, and recordset handling.
+
+## Table of Contents
+
+1. [Recordset Basics](#recordset-basics)
+2. [Search Methods](#search-methods)
+3. [read_group Aggregation](#read_group-aggregation)
+4. [CRUD Operations](#crud-operations)
+5. [Domain Syntax](#domain-syntax)
+6. [Environment Context](#environment-context)
+7. [Recordset Utility Methods](#recordset-utility-methods)
+8. [Iteration Patterns](#iteration-patterns)
+9. [Common Patterns](#common-patterns)
+10. [Advanced Model Attributes](#advanced-model-attributes)
+
+---
+
+## Recordset Basics
+
+### browse() - Retrieve Records by ID
+
+```python
+# Single record (returns a 1-record recordset)
+record = self.browse(1)
+
+# Multiple records
+records = self.browse([1, 2, 3])
+
+# Empty recordset
+empty = self.browse()
+
+# browse() never raises on missing IDs; use .exists() to filter
+```
+
+`browse()` always returns a recordset — even for IDs that do not exist in the database. The missing IDs disappear only once you access a field (which triggers a fetch) or filter with `.exists()`.
+
+```python
+records = self.browse([1, 999, 1000])
+valid_records = records.exists()   # drops missing IDs
+```
+
+### Empty Recordset Patterns
+
+```python
+# GOOD: use boolean context
+if not records:
+    return
+
+# GOOD: filter by condition
+records = records.filtered(lambda r: r.active)
+
+# GOOD: remove ids that no longer exist in DB
+records = records.exists()
+```
+
+### ensure_one() - Assert Single Record
+
+```python
+order = self.env['sale.order'].search([('name', '=', ref)], limit=1)
+order.ensure_one()   # raises ValueError if not exactly 1 record
+```
+
+---
+
+## Search Methods
+
+### search() - Find Records
+
+```python
+# Basic search - returns a recordset
+records = self.search([('state', '=', 'draft')])
+
+# With limit and order
+records = self.search(
+    [('state', '=', 'draft')],
+    limit=10,
+    order='date DESC',
+)
+
+# With offset (pagination)
+records = self.search(
+    [('state', '=', 'draft')],
+    offset=10,
+    limit=10,
+)
+
+# Complex domain (polish notation for operators)
+records = self.search([
+    '&',
+    ('state', '=', 'draft'),
+    '|',
+    ('date', '>=', '2024-01-01'),
+    ('date', '=', False),
+])
+```
+
+Signature in Odoo 16:
+
+```python
+def search(self, domain, offset=0, limit=None, order=None, count=False)
+```
+
+### search() + read() - Odoo 16-Safe Pattern When You Need Dicts
+
+**Use when**: you want normal recordset behavior for the search step, then a list of dicts for selected fields.
+
+```python
+# Search with normal ORM options
+records = self.search(
+    [('state', '=', 'done')],
+    order='date DESC',
+    limit=10,
+)
+
+# Then read only the fields you actually need
+data = records.read(['name', 'amount_total', 'partner_id'])
+```
+
+This keeps the documented Odoo 16 flow on public APIs: `search()` returns a recordset, and `read()` converts that recordset into dictionaries when needed.
+
+### search_read() - Find and Read as Dicts
+
+**Use when**: you need records as plain dicts (e.g. for RPC or reports), not recordsets.
+
+```python
+data = self.search_read(
+    [('state', '=', 'done')],
+    ['name', 'date', 'amount_total'],
+    order='amount_total desc',
+    limit=10,
+)
+# [{'id': 1, 'name': 'SO001', 'date': '2024-01-15', 'amount_total': 100.0}, ...]
+```
+
+`search_read()` is the convenience API when you want dictionaries directly and do not need recordset methods between the search step and the read step.
+
+### search_count() - Count Records
+
+```python
+count = self.search_count([('state', '=', 'draft')])
+```
+
+If you need an existence-style check, keep that separate from `search_count()`. If you intentionally want a capped probe of the first N matches, that is a different pattern and is not a replacement for `search_count()`:
+
+```python
+# At least one matching record?
+has_drafts = bool(self.search([('state', '=', 'draft')], limit=1))
+
+# Probe only the first 100 matching rows
+sample = self.search([('state', '=', 'draft')], limit=100)
+sample_size = len(sample)
+```
+
+### read() - Read Field Values
+
+```python
+# Read specific fields (returns a list of dicts)
+data = records.read(['name', 'state', 'date'])
+# [{'id': 1, 'name': 'Test', 'state': 'draft', 'date': ...}, ...]
+
+# Read all fields
+data = records.read()
+```
+
+For most server-side code, direct attribute access (`record.name`) is preferred over `read()` — Odoo prefetches fields across the recordset automatically.
+
+---
+
+## read_group Aggregation
+
+For Odoo 16 business code, prefer `read_group()`. It is the documented aggregation API and returns dictionaries that are easy to consume in model methods, reports, and UI-oriented code.
+
+`_read_group()` exists in core, but treat it as an internal helper in Odoo 16 documentation. If you inspect or reuse core code that calls `_read_group()`, verify the exact shape in the target Odoo 16 source instead of copying examples from newer versions.
+
+### Aggregate Functions (v16)
+
+Valid aggregate functions in Odoo 16:
+
+| Aggregate | SQL | Result type |
+|-----------|-----|-------------|
+| `__count` | `COUNT(*)` (no field prefix) | `int` |
+| `field:sum` | `SUM(field)` | `float`/`int` |
+| `field:avg` | `AVG(field)` | `float` |
+| `field:max` | `MAX(field)` | field type |
+| `field:min` | `MIN(field)` | field type |
+| `field:count` | `COUNT(field)` | `int` (non-null only) |
+| `field:count_distinct` | `COUNT(DISTINCT field)` | `int` |
+| `field:bool_and` | `BOOL_AND(field)` | `bool` |
+| `field:bool_or` | `BOOL_OR(field)` | `bool` |
+| `field:array_agg` | `ARRAY_AGG(field ORDER BY id)` | `list` |
+Difference between counters:
+
+- `__count` counts every row in the group (like `COUNT(*)`).
+- `field:count` counts rows where `field IS NOT NULL`.
+- `field:count_distinct` counts distinct non-null values.
+
+### Groupby Granularities (v16)
+
+Supported temporal granularities in Odoo 16:
+
+`hour`, `day`, `week`, `month`, `quarter`, `year`.
+
+Odoo 16 does **not** support numeric granularities like `day_of_month`, `month_number`, `iso_week_number`, `hour_number`, etc. (those were introduced in later versions).
+
+### read_group() - Dict Format for UI
+
+```python
+result = self.read_group(
+    domain=[('state', '=', 'draft')],
+    fields=['amount_total:sum'],
+    groupby=['category_id'],
+)
+# [{'category_id': (1, 'Category A'), 'amount_total': 1500.0,
+#   'category_id_count': 3, '__domain': [...], '__context': {...}}]
+
+# `__domain` is useful to drill down:
+for group in result:
+    orders = self.search(group['__domain'])
+```
+
+Multi-groupby:
+
+```python
+data = self.read_group(
+    domain=[('state', '=', 'done')],
+    fields=['partner_id', 'amount_total:sum'],
+    groupby=['partner_id', 'date_order:month'],
+    lazy=False,   # group by ALL fields at once, not only the first one
+)
+```
+
+When you see `_read_group()` in Odoo core or framework code, read it as an implementation detail behind aggregation helpers. For user-facing Odoo 16 guidance, prefer examples built on `read_group()`.
+
+### group_expand (ensure empty groups appear)
+
+```python
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    state = fields.Selection(
+        [('draft', 'Draft'), ('confirmed', 'Confirmed'), ('done', 'Done')],
+        group_expand='_read_group_expand_states',
+    )
+
+    @api.model
+    def _read_group_expand_states(self, states, domain, order):
+        # Always return every state, even those with 0 records
+        return [key for key, _label in type(self).state.selection]
+```
+
+---
+
+## CRUD Operations
+
+### create() - Create New Records
+
+In Odoo 16, the `create()` method receives a **list of vals** and returns a **recordset**. If you override it, you must decorate with `@api.model_create_multi` — otherwise Odoo logs `"The model ... is not overriding the create method in batch"` and falls back to the slow per-record wrapper.
+
+```python
+from odoo import api, fields, models
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals.setdefault('state', 'draft')
+        orders = super().create(vals_list)
+        orders._onboard_new_orders()
+        return orders
+```
+
+Calls are flexible — both dict and list are accepted:
+
+```python
+# Single record (backward-compat, returns 1-record recordset)
+record = self.env['sale.order'].create({'partner_id': 1})
+
+# Batch create - recommended whenever you already have many dicts
+records = self.env['sale.order'].create([
+    {'partner_id': 1},
+    {'partner_id': 2},
+    {'partner_id': 3},
+])
+```
+
+Relational fields in `create()` accept the classic command tuples or the `Command` helpers from `odoo.fields`:
+
+```python
+from odoo import Command
+
+orders = self.env['sale.order'].create([{
+    'partner_id': 1,
+    'order_line': [
+        Command.create({'product_id': 2, 'product_uom_qty': 3}),
+        (0, 0, {'product_id': 5, 'product_uom_qty': 1}),    # equivalent tuple form
+    ],
+    'tag_ids': [Command.set([1, 2, 3])],
+}])
+```
+
+x2many command reference:
+
+| Tuple | `Command` helper | Meaning |
+|-------|------------------|---------|
+| `(0, 0, vals)` | `Command.create(vals)` | Create a new related record |
+| `(1, id, vals)` | `Command.update(id, vals)` | Update existing record |
+| `(2, id, 0)` | `Command.delete(id)` | Delete from DB |
+| `(3, id, 0)` | `Command.unlink(id)` | Remove the relation only |
+| `(4, id, 0)` | `Command.link(id)` | Link an existing record |
+| `(5, 0, 0)` | `Command.clear()` | Remove all relations |
+| `(6, 0, ids)` | `Command.set(ids)` | Replace with this list |
+
+### write() - Update Records
+
+```python
+# Update the whole recordset in one statement
+records.write({'state': 'done'})
+
+# Several fields at once
+records.write({
+    'state': 'done',
+    'date_done': fields.Datetime.now(),
+})
+```
+
+`write()` batches SQL updates for the whole recordset. Never call `write()` inside a `for record in records` loop for a scalar change — it issues N separate statements.
+
+### unlink() - Delete Records
+
+Use `@api.ondelete(at_uninstall=False)` (see the decorator guide) for deletion rules instead of overriding `unlink()`:
+
+```python
+from odoo.exceptions import UserError
+
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_draft(self):
+        if any(order.state != 'draft' for order in self):
+            raise UserError("Only draft orders can be deleted.")
+
+# Deletion itself:
+self.env['sale.order'].browse(ids).unlink()
+```
+
+### copy() - Duplicate Records
+
+```python
+new_record = record.copy(default={'name': f"{record.name} (copy)"})
+```
+
+Fields with `copy=False` (e.g. `state`, dates, sequence numbers) are excluded automatically.
+
+---
+
+## Domain Syntax
+
+### Basic Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `=` | equals | `[('state', '=', 'draft')]` |
+| `!=` | not equals | `[('state', '!=', 'draft')]` |
+| `>` | greater than | `[('amount', '>', 100)]` |
+| `>=` | greater or equal | `[('amount', '>=', 100)]` |
+| `<` | less than | `[('amount', '<', 100)]` |
+| `<=` | less or equal | `[('amount', '<=', 100)]` |
+| `=?` | equals OR value is empty | `[('partner_id', '=?', user_id)]` |
+| `in` | value in list | `[('id', 'in', [1, 2, 3])]` |
+| `not in` | value not in list | `[('id', 'not in', [1, 2, 3])]` |
+| `like` | contains (case-sensitive) | `[('name', 'like', 'test')]` |
+| `ilike` | contains (case-insensitive) | `[('name', 'ilike', 'TEST')]` |
+| `not like` / `not ilike` | negated contains | `[('name', 'not ilike', 'xxx')]` |
+| `=like` / `=ilike` | SQL LIKE without implicit wildcards | `[('code', '=ilike', 'A_1%')]` |
+| `child_of` | record is descendant in a parent hierarchy | `[('category_id', 'child_of', 4)]` |
+| `parent_of` | record is ancestor of given record | `[('company_id', 'parent_of', 5)]` |
+
+### Logical Operators
+
+Polish prefix notation. `&` / `|` take the next two terms; `!` takes the next one.
+
+```python
+# AND is implicit between consecutive terms
+domain = [('state', '=', 'draft'), ('date', '>=', '2024-01-01')]
+
+# OR must be explicit
+domain = [
+    '|',
+    ('state', '=', 'draft'),
+    ('state', '=', 'confirmed'),
+]
+
+# NOT
+domain = ['!', ('state', '=', 'draft')]
+
+# (A OR B) AND (C OR D)
+domain = [
+    '&',
+    '|', ('state', '=', 'draft'),        ('state', '=', 'confirmed'),
+    '|', ('date', '>=', '2024-01-01'),   ('date', '=', False),
+]
+```
+
+### Relational Domain Traversal
+
+```python
+# Dotted paths on Many2one work directly
+domain = [('partner_id.country_id.code', '=', 'US')]
+
+# Dotted traversal across related records can work for simple x2many existence-style filters
+domain = [('line_ids.product_id.categ_id', '=', 1)]
+
+# Find orders that contain a service product
+domain = [('line_ids.product_id.type', '=', 'service')]
+```
+
+If you need more complex "has related record matching X" logic in Odoo 16, prefer valid relation traversal or split the work into two ORM steps. Do not document `any` / `not any` as part of the Odoo 16 public domain syntax.
+
+---
+
+## Environment Context
+
+### with_context() - Set/Override Context Keys
+
+```python
+# Language
+records.with_context(lang='fr_FR').mapped('name')
+
+# Disable the default `active_test=True` so archived records are included
+all_records = self.with_context(active_test=False).search([])
+
+# Binary size instead of content (used in kanban / chatter previews)
+attachments.with_context(bin_size=True).read(['datas'])
+
+# Force a specific allowed-companies list
+records.with_context(allowed_company_ids=[1, 2]).read(['amount_total'])
+
+# Pass a custom key that your own methods/computed fields depend on
+records.with_context(from_cron=True).action_process()
+```
+
+### with_user() / sudo() - Change User
+
+```python
+# Run as a specific user (respects their access rights)
+records.with_user(user).action_confirm()
+
+# Run as the superuser (bypasses security - use sparingly)
+record.sudo().write({'notes': 'System note'})
+```
+
+### with_company() - Change Current Company
+
+```python
+# Temporarily evaluate company-dependent fields for another company
+record.with_company(company).read(['property_account_receivable_id'])
+```
+
+### Environment Properties and Helpers
+
+```python
+# Superuser / admin / system flag
+if self.env.is_superuser():
+    ...
+if self.env.is_admin():
+    ...
+if self.env.is_system():
+    ...
+
+# Current user, company, and enabled companies
+self.env.user        # res.users record
+self.env.company     # res.company record
+self.env.companies   # recordset of all allowed companies
+self.env.lang        # str or None
+
+# ref('module.xml_id') -> record
+default_partner = self.env.ref('base.partner_root')
+
+# Translation function
+from odoo import _
+
+translated = _("Hello %s") % name
+```
+
+### Raw SQL (Odoo 16)
+
+Prefer the ORM. Drop to SQL only for reporting, bulk updates that the ORM would slow down, or for referencing virtual tables. In Odoo 16 the canonical form is:
+
+```python
+self.env.cr.execute(
+    "SELECT id, name FROM sale_order WHERE state = %s",
+    ('done',),
+)
+rows = self.env.cr.fetchall()           # list of tuples
+dicts = self.env.cr.dictfetchall()      # list of dicts
+```
+
+Always flush pending writes to DB before a raw SQL read that depends on them:
+
+```python
+self.env['sale.order'].flush_model(['amount_total'])
+self.env.cr.execute("SELECT SUM(amount_total) FROM sale_order")
+```
+
+---
+
+## Recordset Utility Methods
+
+### mapped() - Extract Field Values
+
+```python
+# Scalar field -> list
+names = records.mapped('name')
+
+# Relational field -> recordset (duplicates removed, order arbitrary)
+partners = records.mapped('partner_id')
+banks = records.mapped('partner_id.bank_ids')
+
+# Lambda -> list (or recordset if the lambda returns recordsets)
+doubled = records.mapped(lambda r: r.amount_total * 2)
+```
+
+### filtered() - Filter by Predicate
+
+```python
+# Lambda
+done_orders = orders.filtered(lambda o: o.state == 'done')
+
+# Short form: field name (including dotted path, True if any related record is truthy)
+companies = partners.filtered('is_company')
+has_banks = partners.filtered('bank_ids')
+```
+
+### filtered_domain() - Filter by Domain
+
+```python
+# Keeps recordset order, evaluates the domain in Python against cached values
+done = orders.filtered_domain([('state', '=', 'done')])
+
+urgent = orders.filtered_domain([
+    '&',
+    ('state', '=', 'draft'),
+    '|', ('priority', '=', '2'),
+        ('date', '<', fields.Date.today()),
+])
+```
+
+### Plain Python Grouping
+
+```python
+from collections import defaultdict
+
+order_ids_by_state = defaultdict(list)
+for order in orders:
+    order_ids_by_state[order.state].append(order.id)
+
+for state, order_ids in order_ids_by_state.items():
+    state_orders = orders.browse(order_ids)
+    print(f"{state}: {len(state_orders)} orders")
+```
+
+Use this as conservative fallback guidance when you do want to partition a recordset in Python, but do not want to rely on higher-level helpers that are not documented here as Odoo 16-safe.
+
+### sorted() - Sort Recordset
+
+```python
+# By field
+records.sorted('name')
+
+# By lambda
+records.sorted(key=lambda r: r.amount_total, reverse=True)
+
+# Default model order (None -> use `_order`)
+records.sorted()
+```
+
+Note that `sorted()` operates in memory on the recordset; for large result sets it is usually faster to add `order=...` to the original `search()` call.
+
+### Comparison
+
+| Method | Returns | Use case |
+|--------|---------|----------|
+| `mapped()` | list or recordset | Extract field values |
+| `filtered()` | recordset | Keep records matching predicate |
+| `filtered_domain()` | recordset | Predicate as a domain (preserves order) |
+| Python grouping (`defaultdict`, `setdefault`) | dict/list | Partition (no aggregation, no SQL) |
+| `sorted()` | recordset | In-memory sort |
+
+---
+
+## Iteration Patterns
+
+### GOOD: Leverage Prefetching
+
+```python
+# Fields are prefetched across the recordset automatically
+for order in orders:
+    print(order.name, order.amount_total, order.partner_id.name)
+# -> 1 query for orders, 1 query for partners
+```
+
+### BAD: N+1 Pattern
+
+```python
+# BAD: search inside the loop -> N queries
+for order in orders:
+    payments = self.env['account.payment'].search([('order_id', '=', order.id)])
+
+# GOOD: one query with IN
+payments_by_order = {}
+payments = self.env['account.payment'].search([('order_id', 'in', orders.ids)])
+for payment in payments:
+    payments_by_order.setdefault(payment.order_id.id, []).append(payment)
+```
+
+### BAD: Writing inside a loop
+
+```python
+# BAD: N UPDATE statements
+for record in records:
+    record.write({'state': 'done'})
+
+# GOOD: 1 UPDATE
+records.write({'state': 'done'})
+
+# GOOD when each record needs a different value: conservative Python-side partitioning
+from collections import defaultdict
+
+record_ids_by_category = defaultdict(list)
+for record in records:
+    record_ids_by_category[record.category_id.id].append(record.id)
+
+categories = records.mapped('category_id')
+for category in categories:
+    subset = self.browse(record_ids_by_category[category.id])
+    subset.write({'computed_field': category.default_value})
+```
+
+This is a conservative fallback for Odoo 16-safe documentation, not a claim that Python grouping should always be your first choice.
+
+---
+
+## Common Patterns
+
+### Check Emptiness
+
+```python
+if not records:
+    return {}
+
+# Don't confuse browse() return with existence check
+records = self.browse(ids).exists()   # drop IDs that no longer exist
+```
+
+### Retrieve Exactly One Record
+
+```python
+record = self.search([('code', '=', code)], limit=1)
+if not record:
+    raise UserError(_("No record found for code %s") % code)
+```
+
+### Raise Missing Error on Stale References
+
+```python
+from odoo.exceptions import MissingError
+
+records = self.browse(ids)
+if len(records.exists()) != len(records):
+    raise MissingError(_("Some records were deleted."))
+```
+
+### Ordered Searches
+
+```python
+# Prefer DB-level order; it's faster and uses indexes
+records = self.search([('state', '=', 'draft')], order='date_order DESC, id DESC')
+```
+
+### Iterating Chunks for Heavy Jobs
+
+```python
+BATCH = 500
+all_records = self.search(domain)
+for i in range(0, len(all_records), BATCH):
+    batch = all_records[i:i + BATCH]
+    batch.action_process()
+    self.env.cr.commit()     # persist progress; only in cron/migration scripts
+```
+
+---
+
+## Advanced Model Attributes
+
+### Model Header Attributes
+
+```python
+class SaleOrder(models.Model):
+    _name = 'sale.order'                 # REQUIRED model name (dot-notation)
+    _description = 'Sales Order'         # human label (used in access rules, logs)
+    _inherit = ['mail.thread']           # mixins / parent models to extend
+    _order = 'date_order DESC, id DESC'  # default ordering for search()
+    _rec_name = 'name'                   # field used for display_name if not overridden
+    _rec_names_search = ['name', 'ref']  # fields scanned by name_search()
+    _check_company_auto = True           # auto-validate check_company=True relations
+```
+
+Odoo 16 **requires** `_name` on every concrete model (there is no auto-naming from the Python class name).
+
+### _parent_store - Hierarchical Optimisation
+
+```python
+class Category(models.Model):
+    _name = 'product.category'
+    _parent_name = 'parent_id'         # default; only set to override
+    _parent_store = True               # enable parent_path storage
+    _order = 'parent_path'
+
+    name = fields.Char(required=True)
+    parent_id = fields.Many2one('product.category', ondelete='cascade')
+    parent_path = fields.Char(index=True, unaccent=False)
+```
+
+`_parent_store=True` maintains a `parent_path` string (`/1/5/17/`). This makes `child_of` / `parent_of` domain operators index-friendly and avoids recursive CTE queries.
+
+### _check_company_auto - Company Consistency
+
+```python
+class Invoice(models.Model):
+    _name = 'account.move'
+    _check_company_auto = True
+
+    company_id = fields.Many2one('res.company', required=True)
+    partner_id = fields.Many2one('res.partner', check_company=True)
+    journal_id = fields.Many2one('account.journal', check_company=True)
+```
+
+When `_check_company_auto=True`, Odoo calls `_check_company()` on `create()` / `write()` and raises a `UserError` if any `check_company=True` relation points to a company that is not compatible with `self.company_id`.
+
+### SQL Constraints (v16)
+
+SQL-level constraints are declared via `_sql_constraints` — a list of `(name, sql_definition, error_message)` triples.
+
+```python
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+
+    _sql_constraints = [
+        ('name_uniq', 'UNIQUE(company_id, name)',
+         'Order reference must be unique per company!'),
+        ('positive_amount', 'CHECK(amount_total >= 0)',
+         'Total amount must be positive.'),
+    ]
+```
+
+### Attribute Reference
+
+| Attribute | Type | Default | Purpose |
+|-----------|------|---------|---------|
+| `_name` | str | — (required) | Model name used in the registry |
+| `_description` | str | `_name` | Human label for logs/ACLs |
+| `_inherit` | str or list | `()` | Models to extend / mix in |
+| `_inherits` | dict | `{}` | Delegation inheritance (`{'parent.model': 'fk_field'}`) |
+| `_order` | str | `'id'` | Default `ORDER BY` clause for `search()` |
+| `_rec_name` | str | `'name'` (if present) | Field used to compute `display_name` |
+| `_rec_names_search` | list | `None` | Fields searched by `name_search()` |
+| `_parent_name` | str | `'parent_id'` | Many2one used for hierarchy |
+| `_parent_store` | bool | `False` | Enable `parent_path` for hierarchical queries |
+| `_fold_name` | str | `'fold'` | Field used for fold state in kanban |
+| `_active_name` | str | auto-detected | Field used for archiving (`active` or `x_active`) |
+| `_check_company_auto` | bool | `False` | Auto-validate `check_company=True` relations |
+| `_sql_constraints` | list | `[]` | `[(name, SQL expression, message), ...]` |
+| `_transient` | bool | `False` | `True` for `TransientModel` (wizards) |
+| `_abstract` | bool | `False` | `True` for `AbstractModel` (no DB table) |
+| `_register` | bool | `True` | Whether to register in the model registry |
+| `_log_access` | bool | `True` | Whether `create_date`, `write_date`, etc. are maintained |
+
+---
+
+## Base Code Reference
+
+The examples in this guide track Odoo 16's source. Verify behaviour in:
+
+- `/Users/unclecat/odoo/16.0/odoo/models.py` — `BaseModel` class, `search*`, `read_group`, `create`, `write`, `unlink`, domain evaluation, recordset utilities.
+- `/Users/unclecat/odoo/16.0/odoo/fields.py` — `Command` enum for x2many operations.
+- `/Users/unclecat/odoo/16.0/odoo/api.py` — `Environment` class and context helpers.
+- `/Users/unclecat/odoo/16.0/odoo/osv/expression.py` — domain operators and relation traversal (`child_of`, `parent_of`, logical operators).

--- a/skills/odoo-16.0/references/odoo-16-owl-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-owl-guide.md
@@ -1,0 +1,1195 @@
+---
+name: odoo-16-owl
+description: Complete reference for Odoo 16 OWL (Owl Web Library) 2.x components, hooks, services, registries, and patterns for building interactive JavaScript UI.
+globs: "**/static/src/**/*.{js,xml,scss}"
+topics:
+  - OWL basics (Component, setup, template, props, state)
+  - OWL hooks (useState, useRef, useEffect, useService, useSubEnv, onMounted, onWillStart, onWillUnmount)
+  - Odoo services (rpc, orm, notification, dialog, action, user, router, ui)
+  - QWeb templates and directives
+  - Registries (category, add, get, contains, fields, views, services, main_components)
+  - Patching existing classes and services
+  - Assets and module structure
+when_to_use:
+  - Creating custom UI components
+  - Writing field widgets or view renderers
+  - Implementing client actions
+  - Extending or patching existing components
+  - Calling backend from the frontend
+---
+
+# Odoo 16 OWL Guide
+
+Complete reference for Odoo 16 OWL (Owl Web Library) 2.x components, hooks, services, and patterns.
+
+Odoo 16 ships with **OWL 2.x** (`addons/web/static/lib/owl/owl.js`). The exact sub-version can vary by source snapshot, but the component syntax is class-based with a `setup()` method and `static template`.
+
+## Table of Contents
+
+1. [OWL Basics](#owl-basics)
+2. [Component Lifecycle](#component-lifecycle)
+3. [OWL Hooks](#owl-hooks)
+4. [Services (Odoo 16 specifics)](#services-odoo-16-specifics)
+5. [QWeb Templates](#qweb-templates)
+6. [Registries](#registries)
+7. [Patching](#patching)
+8. [Assets and File Layout](#assets-and-file-layout)
+9. [Common Patterns](#common-patterns)
+10. [Best Practices](#best-practices)
+11. [Complete Example](#complete-example)
+
+---
+
+## OWL Basics
+
+### Importing from @odoo/owl
+
+```javascript
+/** @odoo-module **/
+import {
+    Component,
+    xml,
+    useState,
+    useRef,
+    useEffect,
+    useSubEnv,
+    onMounted,
+    onWillStart,
+    onWillUnmount,
+} from "@odoo/owl";
+```
+
+All OWL primitives come from the `@odoo/owl` package. Odoo-specific hooks live in `@web/core/utils/hooks` and `@web/core/...`.
+
+### Basic Component Structure
+
+```javascript
+/** @odoo-module **/
+import { Component, useState } from "@odoo/owl";
+
+export class Counter extends Component {
+    static template = "my_module.Counter";
+    static props = {
+        initial: { type: Number, optional: true },
+        onChange: { type: Function, optional: true },
+    };
+    static defaultProps = { initial: 0 };
+
+    setup() {
+        this.state = useState({ value: this.props.initial });
+    }
+
+    increment() {
+        this.state.value++;
+        this.props.onChange?.(this.state.value);
+    }
+}
+```
+
+### Template in a Separate XML File (Recommended)
+
+`my_module/static/src/counter/counter.js`:
+
+```javascript
+/** @odoo-module **/
+import { Component, useState } from "@odoo/owl";
+
+export class Counter extends Component {
+    static template = "my_module.Counter";
+    static props = { initial: { type: Number, optional: true } };
+
+    setup() {
+        this.state = useState({ value: this.props.initial || 0 });
+    }
+
+    increment() {
+        this.state.value++;
+    }
+}
+```
+
+`my_module/static/src/counter/counter.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="my_module.Counter" owl="1">
+        <div class="counter">
+            <button type="button" class="btn btn-primary" t-on-click="increment">
+                Count: <t t-esc="state.value"/>
+            </button>
+        </div>
+    </t>
+</templates>
+```
+
+Convention: the template `t-name` should follow `addon_name.ComponentName`; that is a template-name convention, not a filename convention. Put the XML file alongside the component.
+
+### Inline Template with `xml` (Small Components)
+
+```javascript
+import { Component, xml, useState } from "@odoo/owl";
+
+export class Tiny extends Component {
+    static template = xml`
+        <div t-on-click="onClick">
+            <t t-esc="state.label"/>
+        </div>
+    `;
+
+    setup() {
+        this.state = useState({ label: "Click me" });
+    }
+
+    onClick() {
+        this.state.label = "Clicked!";
+    }
+}
+```
+
+Prefer external XML files for anything non-trivial — you get proper indentation and `web-editor` support for translatable strings.
+
+---
+
+## Component Lifecycle
+
+### Hooks Fired in Order
+
+```javascript
+import {
+    onWillStart,
+    onWillRender,
+    onRendered,
+    onMounted,
+    onWillUpdateProps,
+    onWillPatch,
+    onPatched,
+    onWillUnmount,
+    onWillDestroy,
+} from "@odoo/owl";
+
+setup() {
+    onWillStart(async () => {
+        // Async setup before first render. Good for loading data.
+        this.records = await this.orm.searchRead("res.partner", [], ["name"]);
+    });
+    onMounted(() => {
+        // DOM is live. Safe to integrate third-party libs.
+    });
+    onWillUpdateProps((nextProps) => { /* before props change */ });
+    onWillPatch(() => { /* before DOM patch */ });
+    onPatched(() => { /* after DOM patch */ });
+    onWillUnmount(() => {
+        // Tear down listeners / timers.
+    });
+    onWillDestroy(() => { /* final cleanup */ });
+}
+```
+
+### Always Use `setup()`, Never `constructor`
+
+```javascript
+// CORRECT
+class Good extends Component {
+    setup() {
+        this.state = useState({ n: 0 });
+    }
+}
+
+// WRONG
+class Bad extends Component {
+    constructor(parent, props) {
+        super(parent, props);
+        this.state = useState({ n: 0 });  // Breaks in subclasses and patches.
+    }
+}
+```
+
+`setup()` is overridable; `constructor` is not. The whole Odoo extension ecosystem relies on overriding `setup()`.
+
+---
+
+## OWL Hooks
+
+### useState — Reactive State
+
+```javascript
+import { useState } from "@odoo/owl";
+
+setup() {
+    this.state = useState({
+        count: 0,
+        user: { name: "Alice", email: "a@x.com" },
+        tags: ["a", "b"],
+    });
+}
+
+// Any assignment in reactive paths triggers a re-render:
+this.state.count++;
+this.state.user.name = "Bob";
+this.state.tags.push("c");
+```
+
+### useRef — DOM References
+
+```javascript
+import { useRef, onMounted } from "@odoo/owl";
+
+setup() {
+    this.input = useRef("input");
+    onMounted(() => this.input.el?.focus());
+}
+```
+
+```xml
+<input t-ref="input" type="text"/>
+```
+
+Access `this.input.el` — it is `null` before mount and after unmount.
+
+### useEffect — Side Effects
+
+```javascript
+import { useEffect } from "@odoo/owl";
+
+setup() {
+    this.state = useState({ query: "" });
+
+    // Runs whenever state.query changes
+    useEffect(
+        (query) => {
+            this.search(query);
+            return () => this.cancelSearch();  // cleanup
+        },
+        () => [this.state.query],
+    );
+}
+```
+
+### useService — Injected Odoo Services
+
+Defined in `@web/core/utils/hooks`:
+
+```javascript
+import { useService } from "@web/core/utils/hooks";
+
+setup() {
+    this.rpc = useService("rpc");                 // Call Python / JSON-RPC URLs
+    this.orm = useService("orm");                 // High-level ORM helper
+    this.notification = useService("notification");
+    this.dialog = useService("dialog");
+    this.action = useService("action");
+    this.user = useService("user");
+    this.router = useService("router");
+    this.ui = useService("ui");
+}
+```
+
+`useService` throws if the service is not registered. For services that declare async behavior in their metadata, pending async calls are guarded so a destroyed component does not resume with stale results.
+
+### useSubEnv — Scoped Environment
+
+```javascript
+import { useSubEnv } from "@odoo/owl";
+
+setup() {
+    useSubEnv({
+        model: this.props.record.resModel,
+        resId: this.props.record.resId,
+    });
+}
+```
+
+Child components can read from `this.env.model` etc. Use sparingly — prefer props.
+
+### Odoo-Specific Hooks
+
+From `@web/core/utils/hooks`:
+
+- `useBus(bus, eventName, callback)` — attach/detach a bus listener with proper cleanup.
+
+Other helpers exist in this module, but verify the exact export set in your Odoo 16 server's `addons/web/static/src/core/utils/hooks.js` before depending on less common hooks.
+
+---
+
+## Services (Odoo 16 specifics)
+
+### RPC Service
+
+In Odoo 16, obtain `rpc` with `useService("rpc")`.
+
+```javascript
+import { useService } from "@web/core/utils/hooks";
+
+setup() {
+    this.rpc = useService("rpc");
+}
+
+async load() {
+    // Direct controller call; params becomes the JSON-RPC `params` object.
+    const result = await this.rpc("/my_module/data", { domain: [["state", "=", "open"]] });
+
+    // call_kw is what the ORM service wraps; usually prefer this.orm instead.
+    const partners = await this.rpc("/web/dataset/call_kw/res.partner/search_read", {
+        model: "res.partner",
+        method: "search_read",
+        args: [[["is_company", "=", true]]],
+        kwargs: { fields: ["name", "email"] },
+    });
+}
+```
+
+### ORM Service
+
+`@web/core/orm_service.js` exposes typed helpers over `/web/dataset/call_kw/...`.
+
+```javascript
+this.orm = useService("orm");
+
+// searchRead(model, domain, fields?, kwargs?)
+const partners = await this.orm.searchRead(
+    "res.partner",
+    [["customer_rank", ">", 0]],
+    ["name", "email", "phone"],
+    { limit: 80, offset: 0 },
+);
+
+// read(model, ids, fields?, kwargs?)
+const records = await this.orm.read("res.partner", [1, 2, 3], ["name"]);
+
+// create(model, recordsList, kwargs?) — pass a LIST of dicts.
+// For the single-record case shown here, Odoo 16 returns the created id.
+const id = await this.orm.create("res.partner", [
+    { name: "New Partner", email: "new@x.com" },
+]);
+
+// write(model, ids, values, kwargs?)
+await this.orm.write("res.partner", ids, { phone: "555" });
+
+// unlink(model, ids, kwargs?)
+await this.orm.unlink("res.partner", ids);
+
+// readGroup(model, domain, fields, groupby, kwargs?)
+const groups = await this.orm.readGroup(
+    "sale.order",
+    [["state", "!=", "draft"]],
+    ["amount_total:sum"],
+    ["state"],
+);
+
+// searchCount(model, domain, kwargs?)
+const count = await this.orm.searchCount("res.partner", [["customer_rank", ">", 0]]);
+
+// call(model, method, args?, kwargs?) — arbitrary server method
+const res = await this.orm.call("my.model", "action_validate", [recordIds]);
+
+// Silent variant — no global RPC indicator
+await this.orm.silent.read("res.partner", [1], ["name"]);
+```
+
+### Notification Service
+
+In Odoo 16 the notification API is `notification.add(message, options)` (NOT `notification.notify(...)`).
+
+```javascript
+this.notification = useService("notification");
+
+// Simple
+this.notification.add("Record saved");
+
+// With options
+this.notification.add("Something failed", {
+    type: "danger",       // "success" | "info" | "warning" | "danger"
+    title: "Error",
+    sticky: true,
+    className: "o_my_notif",
+    onClose: () => console.log("closed"),
+    buttons: [
+        { name: "Retry", primary: true, onClick: () => this.retry() },
+    ],
+});
+
+// add() returns a close function
+const close = this.notification.add("Working...", { sticky: true });
+// later:
+close();
+```
+
+### Dialog Service
+
+```javascript
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+this.dialog = useService("dialog");
+
+// dialog.add(Component, props, options?)
+this.dialog.add(ConfirmationDialog, {
+    title: _t("Delete record"),
+    body: _t("Are you sure? This cannot be undone."),
+    confirmLabel: _t("Delete"),
+    confirm: async () => {
+        await this.orm.unlink(this.props.resModel, [this.props.resId]);
+    },
+    cancel: () => {},
+});
+```
+
+`dialog.add` returns a `close` function. The optional third argument accepts `{ onClose }`.
+
+Custom dialog components receive a `close` prop to dismiss themselves.
+
+### Action Service
+
+```javascript
+this.action = useService("action");
+
+// Open an act_window
+await this.action.doAction({
+    type: "ir.actions.act_window",
+    name: "Partners",
+    res_model: "res.partner",
+    views: [[false, "tree"], [false, "form"]],
+    domain: [["customer_rank", ">", 0]],
+    target: "current",        // "current" | "new" | "fullscreen" | "inline"
+});
+
+// Open a specific form view
+await this.action.doAction({
+    type: "ir.actions.act_window",
+    res_model: "res.partner",
+    res_id: partnerId,
+    views: [[false, "form"]],
+    target: "new",
+});
+
+// Run a server action or report by XML-id / database id
+await this.action.doAction("my_module.action_my_report", {
+    additionalContext: { default_state: "draft" },
+});
+
+// Execute a view button action descriptor
+await this.action.doActionButton({
+    type: "object",
+    name: "action_confirm",
+    resModel: "sale.order",
+    resId: orderId,
+    resIds: [orderId],
+});
+```
+
+### User Service
+
+Read-only snapshot of the current user, plus a cached `user.hasGroup(...)`.
+
+```javascript
+this.user = useService("user");
+
+this.user.userId;        // integer
+this.user.name;
+this.user.context;
+this.user.lang;
+this.user.tz;
+this.user.isAdmin;
+
+if (await this.user.hasGroup("base.group_system")) {
+    // ...
+}
+```
+
+For company-related data, prefer reading the active company information from the session/context your screen already receives, and verify any convenience properties against your Odoo 16 `user_service.js` before relying on them by name.
+
+### Router Service
+
+```javascript
+this.router = useService("router");
+
+// Read current URL state
+const hash = this.router.current.hash;
+
+// Push updates to the URL hash
+this.router.pushState({ view_type: "tree", action: 42 }, { replace: false });
+```
+
+### UI Service
+
+```javascript
+this.ui = useService("ui");
+
+this.ui.isSmall;                // boolean: mobile breakpoint
+this.ui.size;                   // Current SIZES enum value
+this.ui.activateElement(el);    // Track a new UI active element
+this.ui.block();                // Block the whole UI
+this.ui.unblock();
+```
+
+---
+
+## QWeb Templates
+
+### Directives
+
+```xml
+<!-- Render value (escaped) -->
+<t t-esc="state.value"/>
+
+<!-- Render value with normal escaping; if you pass markup(...) / other safe markup, Owl trusts it and injects that HTML without escaping -->
+<t t-out="state.safeHtml"/>
+
+<!-- Conditionals -->
+<div t-if="state.isActive">Active</div>
+<div t-elif="state.isPending">Pending</div>
+<div t-else="">Idle</div>
+
+<!-- Loops (always include t-key) -->
+<t t-foreach="state.records" t-as="rec" t-key="rec.id">
+    <div t-esc="rec.name"/>
+</t>
+
+<!-- Dynamic attributes -->
+<input t-att-value="state.value"/>
+<div t-att-class="state.isActive ? 'o_active' : ''"/>
+<div t-att="{'data-id': rec.id, 'data-name': rec.name}"/>
+<a t-attf-href="/record/{{ rec.id }}">Open</a>
+
+<!-- Event handlers -->
+<button type="button" t-on-click="onClick">Click</button>
+<button type="button" t-on-click.stop="onClick">Click (stop propagation)</button>
+<button type="button" t-on-click="() => this.select(item)">Inline arrow</button>
+<input t-on-input="onInput"/>
+
+<!-- Two-way binding -->
+<input t-model="state.search"/>
+<input type="checkbox" t-model="state.isOn"/>
+
+<!-- Local variable -->
+<t t-set="total" t-value="state.items.reduce((a, b) => a + b.qty, 0)"/>
+
+<!-- Call another template -->
+<t t-call="my_module.SubTemplate">
+    <t t-set="extra" t-value="'hi'"/>
+</t>
+
+<!-- Reference to DOM element -->
+<input t-ref="searchInput"/>
+```
+
+### Slots
+
+Parent exposes slots; children fill them:
+
+```xml
+<!-- Parent template -->
+<t t-name="my_module.Card" owl="1">
+    <div class="card">
+        <div class="card-header">
+            <t t-slot="header"/>
+        </div>
+        <div class="card-body">
+            <t t-slot="default"/>
+        </div>
+    </div>
+</t>
+
+<!-- Usage -->
+<Card>
+    <t t-set-slot="header"><h3>Title</h3></t>
+    <p>Body content</p>
+</Card>
+```
+
+Scoped slots pass data to the slot content:
+
+```xml
+<!-- Parent -->
+<t t-foreach="items" t-as="item" t-key="item.id">
+    <t t-slot="item" item="item"/>
+</t>
+
+<!-- Child -->
+<MyList>
+    <t t-set-slot="item" t-slot-scope="scope">
+        <span t-esc="scope.item.name"/>
+    </t>
+</MyList>
+```
+
+### Sub-Component Usage
+
+```javascript
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+
+export class Toolbar extends Component {
+    static template = "my_module.Toolbar";
+    static components = { Dropdown, DropdownItem };
+}
+```
+
+```xml
+<t t-name="my_module.Toolbar" owl="1">
+    <Dropdown>
+        <button type="button" class="btn btn-primary">Actions</button>
+        <t t-set-slot="content">
+            <DropdownItem onSelected="() => this.save()">Save</DropdownItem>
+            <DropdownItem onSelected="() => this.discard()">Discard</DropdownItem>
+        </t>
+    </Dropdown>
+</t>
+```
+
+---
+
+## Registries
+
+`@web/core/registry` exposes a central registry with named categories. Registering under the right category is how Odoo discovers your widget/view/service.
+
+```javascript
+import { registry } from "@web/core/registry";
+```
+
+### Common Categories
+
+| Category | What it holds |
+|----------|---------------|
+| `"services"` | OWL services (rpc, orm, notification, dialog, action, …) |
+| `"main_components"` | Top-level components mounted in the webclient shell |
+| `"fields"` | Field widgets (used by form/list views via `widget="..."`) |
+| `"views"` | View definitions (list, form, kanban, graph, …) |
+| `"actions"` | Client actions (used by `ir.actions.client`) |
+| `"systray"` | Systray items |
+| `"user_menuitems"` | User menu entries |
+| `"formatters"` / `"parsers"` | Field formatters / parsers |
+
+### Registering a Service
+
+```javascript
+import { registry } from "@web/core/registry";
+
+export const myService = {
+    dependencies: ["rpc", "user"],
+    start(env, { rpc, user }) {
+        return {
+            async doStuff(id) {
+                return rpc("/my/endpoint", { id });
+            },
+        };
+    },
+};
+
+registry.category("services").add("myService", myService);
+```
+
+Then `this.myService = useService("myService");` from any component.
+
+### Registering a Field Widget
+
+```javascript
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+export class ColoredBadge extends Component {
+    static template = "my_module.ColoredBadge";
+    static props = { ...standardFieldProps };
+
+    get value() {
+        return this.props.record.data[this.props.name];
+    }
+}
+
+export const coloredBadge = {
+    component: ColoredBadge,
+    displayName: "Colored Badge",
+    supportedTypes: ["char"],
+    extractProps: ({ attrs, options }) => ({
+        // Map arch attrs to component props if needed
+    }),
+};
+
+registry.category("fields").add("colored_badge", coloredBadge);
+```
+
+Use in a view: `<field name="state" widget="colored_badge"/>`.
+
+### Registering a Client Action
+
+```javascript
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+
+class Dashboard extends Component {
+    static template = "my_module.Dashboard";
+}
+
+registry.category("actions").add("my_module.dashboard", Dashboard);
+```
+
+Then create an `ir.actions.client`:
+
+```xml
+<record id="action_dashboard" model="ir.actions.client">
+    <field name="name">Dashboard</field>
+    <field name="tag">my_module.dashboard</field>
+</record>
+```
+
+### Other Registry Operations
+
+```javascript
+const cat = registry.category("fields");
+
+cat.add("my_widget", def);             // throws if already registered
+cat.add("my_widget", def, { force: true });
+cat.get("my_widget");                  // throws if missing
+cat.get("my_widget", defaultValue);    // safe variant
+cat.contains("my_widget");             // boolean
+cat.remove("my_widget");
+cat.getAll();                          // array of values
+cat.getEntries();                      // array of [key, value]
+```
+
+---
+
+## Patching
+
+Prefer supported extension points first in Odoo 16: registries, services, component composition, subclassing where the framework exposes it, and documented hooks. Reach for `patch(...)` only when those options do not cover the behavior you need.
+
+When patching is unavoidable, import it from `@web/core/utils/patch` and use the Odoo 16 signature `patch(obj, patchName, patchValue, options)`:
+
+```javascript
+import { patch } from "@web/core/utils/patch";
+import { FormController } from "@web/views/form/form_controller";
+
+patch(FormController.prototype, "my_module.FormController", {
+    // Wrap a real Odoo 16 method only after confirming you truly need a patch.
+    async saveButtonClicked(params = {}) {
+        const _super = this._super.bind(this);
+        const saved = await _super(...arguments);
+        if (saved) {
+            console.log("Form save completed");
+        }
+        return saved;
+    },
+
+    // Add a new method
+    myHelper() {
+        return 42;
+    },
+});
+```
+
+Notes:
+
+- Treat patching as a fallback for framework code you cannot extend cleanly through registries or other documented APIs.
+- Pass the **prototype** when patching instance methods of a class.
+- Pass the **class itself** when patching static members.
+- The second argument is a unique patch name string; it must stay unique unless the old patch is removed first with `unpatch(obj, patchName)`.
+- In sync methods, call the parent implementation with `this._super(...arguments)`.
+- In async methods, bind `_super` before the first `await` because `this._super` is reassigned for each patched call.
+- Keep patches small and narrowly scoped so future framework updates are easier to review.
+- To remove a patch in tests, import and call `unpatch(obj, patchName)` explicitly.
+
+Patching a service:
+
+```javascript
+import { patch } from "@web/core/utils/patch";
+import { ORM } from "@web/core/orm_service";
+
+patch(ORM.prototype, "my_module.orm_logging", {
+    async searchRead(model, domain, fields, kwargs = {}) {
+        const _super = this._super.bind(this);
+        console.log("searchRead", model, domain);
+        return _super(model, domain, fields, kwargs);
+    },
+});
+```
+
+---
+
+## Assets and File Layout
+
+### File Structure
+
+```
+my_module/static/src/
+├── components/
+│   ├── my_widget/
+│   │   ├── my_widget.js
+│   │   ├── my_widget.xml
+│   │   └── my_widget.scss
+│   └── other_thing/
+│       └── ...
+├── client_actions/
+│   └── partner_panel/
+│       ├── partner_panel.js
+│       └── partner_panel.xml
+├── views/
+│   └── my_view/
+│       └── ...
+└── services/
+    └── my_service.js
+```
+
+### Asset Bundles in `__manifest__.py`
+
+```python
+{
+    'name': 'My Module',
+    'version': '16.0.1.0.0',
+    'depends': ['web'],
+    'assets': {
+        'web.assets_backend': [
+            'my_module/static/src/components/**/*',
+            'my_module/static/src/services/**/*',
+            'my_module/static/src/client_actions/**/*',
+        ],
+        'web.assets_frontend': [
+            'my_module/static/src/public/**/*',
+        ],
+        'web.assets_common': [
+            'my_module/static/src/common/**/*',
+        ],
+    },
+}
+```
+
+Common bundles in Odoo 16:
+
+- `web.assets_backend` — back-end webclient.
+- `web.assets_frontend` — website / portal frontend.
+- `web.assets_common` — shared by both.
+- `web.report_assets_common` — PDF reports.
+- `web.qunit_suite_tests` — QUnit tests.
+
+Declare XML templates inside the same manifest bundle as the JavaScript that uses them. In practice, colocated component folders such as `static/src/components/**/*` or `static/src/client_actions/**/*` are a good default, because both the `.js` and `.xml` files are picked up together.
+
+---
+
+## Common Patterns
+
+### Loading Data in `onWillStart`
+
+```javascript
+import { Component, useState, onWillStart } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class PartnerList extends Component {
+    static template = "my_module.PartnerList";
+    static props = { domain: { type: Array, optional: true } };
+    static defaultProps = { domain: [] };
+
+    setup() {
+        this.orm = useService("orm");
+        this.state = useState({ partners: [] });
+
+        onWillStart(async () => {
+            this.state.partners = await this.orm.searchRead(
+                "res.partner",
+                this.props.domain,
+                ["name", "email"],
+                { limit: 80 },
+            );
+        });
+    }
+}
+```
+
+### Props Validation
+
+```javascript
+static props = {
+    // Required
+    record: Object,
+
+    // Optional primitive
+    title: { type: String, optional: true },
+
+    // Union
+    value: { type: [String, Number], optional: true },
+
+    // Array of strings
+    tags: { type: Array, element: String, optional: true },
+
+    // Object shape
+    config: {
+        type: Object,
+        shape: { limit: Number, offset: Number },
+        optional: true,
+    },
+
+    // Function
+    onSave: { type: Function, optional: true },
+
+    // Accept anything else (slot spec etc.)
+    slots: { type: Object, optional: true },
+};
+
+static defaultProps = { tags: [] };
+```
+
+Avoid `static props = ["*"]` (accept any prop) in user code — it silently hides typos.
+
+### Using `_t` for Translations
+
+```javascript
+import { _t } from "@web/core/l10n/translation";
+
+this.notification.add(_t("Record saved"));
+this.dialog.add(ConfirmationDialog, {
+    title: _t("Confirm"),
+    body: _t("Are you sure?"),
+});
+```
+
+`_t` is picked up by Odoo's translation export. Do NOT concatenate translated strings, and do not pass interpolation values directly to `_t(...)` in Odoo 16 JS. Translate first, then format the result:
+
+```javascript
+import { sprintf } from "@web/core/utils/strings";
+
+sprintf(_t("Hello %s"), name); // good
+// bad: avoid passing interpolation args directly to _t(...) in Odoo 16 JS
+_t("Hello ") + name;           // bad: not fully translatable
+```
+
+### Cleaning Up
+
+```javascript
+setup() {
+    const timer = setInterval(() => this.tick(), 1000);
+    onWillUnmount(() => clearInterval(timer));
+}
+```
+
+---
+
+## Best Practices
+
+### DO
+
+1. Always use `setup()` (never `constructor`).
+2. Put templates in dedicated `.xml` files colocated with the component; keep `addon.ComponentName` for the template `t-name`, not the filename.
+3. Load async data in `onWillStart` — components don't render until it resolves.
+4. Declare `static props` explicitly; avoid `["*"]`.
+5. Use services (`useService`) for cross-cutting concerns rather than imports.
+6. Clean up timers / bus listeners in `onWillUnmount`.
+7. Use `_t` from `@web/core/l10n/translation` for every user-visible string.
+8. Use `t-key` on every `t-foreach`.
+9. Interact with the DOM only through `useRef` + lifecycle hooks.
+10. Prefer registries, services, hooks, and composition before patching; if you must patch, use `patch(Cls.prototype, "my_module.patch_name", { ... })` and call the parent implementation through `this._super(...)`.
+
+### DON'T
+
+1. Don't override `constructor` — you cannot reach it from subclass `setup()`.
+2. Don't import `rpc` as a plain function — in Odoo 16 it is a service (`useService("rpc")`).
+3. Don't call `notification.notify(...)` — the v16 API is `notification.add(message, options)`.
+4. Don't query the DOM with `document.querySelector` — use refs.
+5. Don't mutate `this.props` — props are read-only.
+6. Don't store persistent state in plain object properties when you want reactivity — use `useState`.
+7. Don't forget to register your service/component in the right registry category.
+
+---
+
+## Complete Example
+
+A client action that lists partners with search, multi-select, and bulk archive.
+
+`my_module/static/src/client_actions/partner_panel/partner_panel.js`:
+
+```javascript
+/** @odoo-module **/
+import { Component, useState, onWillStart } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { sprintf } from "@web/core/utils/strings";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+export class PartnerPanel extends Component {
+    static template = "my_module.PartnerPanel";
+    static components = { Dropdown, DropdownItem };
+    static props = {};
+
+    setup() {
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+        this.dialog = useService("dialog");
+
+        this.state = useState({
+            partners: [],
+            selected: new Set(),
+            search: "",
+            loading: false,
+        });
+
+        onWillStart(() => this.load());
+    }
+
+    async load() {
+        this.state.loading = true;
+        try {
+            this.state.partners = await this.orm.searchRead(
+                "res.partner",
+                [["active", "=", true]],
+                ["name", "email", "phone"],
+                { limit: 100 },
+            );
+        } catch (error) {
+            this.notification.add(_t("Failed to load partners"), { type: "danger" });
+            throw error;
+        } finally {
+            this.state.loading = false;
+        }
+    }
+
+    get filteredPartners() {
+        const q = this.state.search.toLowerCase();
+        if (!q) {
+            return this.state.partners;
+        }
+        return this.state.partners.filter((p) => p.name.toLowerCase().includes(q));
+    }
+
+    toggle(id) {
+        if (this.state.selected.has(id)) {
+            this.state.selected.delete(id);
+        } else {
+            this.state.selected.add(id);
+        }
+        // Trigger reactivity on Set
+        this.state.selected = new Set(this.state.selected);
+    }
+
+    onSearchInput(ev) {
+        this.state.search = ev.target.value;
+    }
+
+    get searchPlaceholder() {
+        return _t("Search...");
+    }
+
+    get actionsLabel() {
+        return _t("Actions");
+    }
+
+    get archiveSelectedLabel() {
+        return _t("Archive selected");
+    }
+
+    get loadingLabel() {
+        return _t("Loading...");
+    }
+
+    async archiveSelected() {
+        const ids = [...this.state.selected];
+        if (!ids.length) {
+            this.notification.add(_t("No partners selected"), { type: "warning" });
+            return;
+        }
+        this.dialog.add(ConfirmationDialog, {
+            title: _t("Archive partners"),
+            body: sprintf(_t("Archive %s partner(s)?"), ids.length),
+            confirm: async () => {
+                await this.orm.write("res.partner", ids, { active: false });
+                this.state.selected = new Set();
+                await this.load();
+                this.notification.add(_t("Partners archived"), { type: "success" });
+            },
+            cancel: () => {},
+        });
+    }
+}
+
+registry.category("actions").add("my_module.partner_panel", PartnerPanel);
+```
+
+`my_module/static/src/client_actions/partner_panel/partner_panel.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="my_module.PartnerPanel" owl="1">
+        <div class="o_partner_panel p-3">
+            <div class="d-flex gap-2 mb-3">
+                <input
+                    type="text"
+                    class="form-control"
+                    t-att-placeholder="searchPlaceholder"
+                    t-att-value="state.search"
+                    t-on-input="onSearchInput"
+                />
+                <Dropdown>
+                    <button type="button" class="btn btn-primary">
+                        <t t-esc="actionsLabel"/>
+                    </button>
+                    <t t-set-slot="content">
+                        <DropdownItem onSelected="() => this.archiveSelected()">
+                            <t t-esc="archiveSelectedLabel"/>
+                        </DropdownItem>
+                    </t>
+                </Dropdown>
+            </div>
+
+            <div t-if="state.loading" class="text-center text-muted">
+                <i class="fa fa-spinner fa-spin"/> <t t-esc="loadingLabel"/>
+            </div>
+
+            <div class="list-group" t-else="">
+                <t t-foreach="filteredPartners" t-as="p" t-key="p.id">
+                    <button
+                        type="button"
+                        class="list-group-item list-group-item-action d-flex justify-content-between"
+                        t-att-class="state.selected.has(p.id) ? 'active' : ''"
+                        t-on-click="() => this.toggle(p.id)"
+                    >
+                        <span>
+                            <strong t-esc="p.name"/>
+                            <small t-if="p.email" class="text-muted ms-2" t-esc="p.email"/>
+                        </span>
+                        <i class="fa fa-check" t-if="state.selected.has(p.id)"/>
+                    </button>
+                </t>
+            </div>
+        </div>
+    </t>
+</templates>
+```
+
+`my_module/__manifest__.py` excerpt:
+
+```python
+'assets': {
+    'web.assets_backend': [
+        'my_module/static/src/client_actions/**/*',
+    ],
+},
+```
+
+`my_module/views/client_action.xml`:
+
+```xml
+<odoo>
+    <record id="action_partner_panel" model="ir.actions.client">
+        <field name="name">Partner Panel</field>
+        <field name="tag">my_module.partner_panel</field>
+    </record>
+</odoo>
+```
+
+---
+
+## Base Code Reference
+
+The APIs documented here live in the Odoo 16 source:
+
+- `addons/web/static/lib/owl/owl.js` — OWL 2.x (`Component`, `useState`, `useRef`, `useEffect`, lifecycle hooks, `xml`).
+- `addons/web/static/src/core/utils/hooks.js` — `useService`, `useBus`, and other Odoo-specific hook helpers.
+- `addons/web/static/src/core/registry.js` — the registry singleton and categories.
+- `addons/web/static/src/core/network/rpc_service.js` — the `rpc` service.
+- `addons/web/static/src/core/orm_service.js` — the `orm` service (`ORM` class API).
+- `addons/web/static/src/core/notifications/notification_service.js` — `notification.add`.
+- `addons/web/static/src/core/dialog/dialog_service.js` — `dialog.add`.
+- `addons/web/static/src/webclient/actions/action_service.js` — `action.doAction`, `doActionButton`.
+- `addons/web/static/src/core/utils/patch.js` — `patch(obj, patchName, patchValue, options)` and `unpatch(obj, patchName)`.
+- `addons/web/static/src/core/l10n/translation.js` — `_t` helper.

--- a/skills/odoo-16.0/references/odoo-16-performance-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-performance-guide.md
@@ -1,0 +1,730 @@
+---
+name: odoo-16-performance
+description: Complete guide for writing performant Odoo 16 code, focusing on N+1 query prevention, batch operations, and optimization patterns.
+globs: "**/*.{py,xml}"
+topics:
+  - Prefetch mechanism (how it works, understanding groups)
+  - N+1 query prevention patterns
+  - Batch operations (create, write, unlink)
+  - Field selection optimization (search_read, load, bin_size)
+  - Aggregation optimization (read_group public API, _read_group caveats)
+  - Compute field optimization (store, precompute, avoiding recursion)
+  - SQL optimization (cr.execute, parameterized SQL)
+  - Clean code patterns (mapped, filtered, sorted)
+when_to_use:
+  - Optimizing slow code
+  - Preventing N+1 queries
+  - Writing batch operations
+  - Optimizing computed fields
+  - Using read_group() for aggregations
+  - Using direct SQL for aggregations
+---
+
+# Odoo 16 Performance Guide
+
+Complete guide for writing performant Odoo 16 code, focusing on N+1 query prevention and clean patterns.
+
+## Table of Contents
+
+1. [Prefetch Mechanism](#prefetch-mechanism)
+2. [N+1 Query Prevention](#n1-query-prevention)
+3. [Batch Operations](#batch-operations)
+4. [Field Selection Optimization](#field-selection-optimization)
+5. [Compute Field Optimization](#compute-field-optimization)
+6. [SQL Optimization](#sql-optimization)
+7. [Flush & Cache Control](#flush--cache-control)
+8. [Clean Code Patterns](#clean-code-performance-patterns)
+9. [Profiling & Query Count](#profiling--query-count)
+
+---
+
+## Prefetch Mechanism
+
+### How Prefetch Works
+
+Odoo automatically prefetches records in batches to minimize queries.
+
+```python
+# Constants from odoo/models.py
+PREFETCH_MAX = 1000          # Maximum records prefetched per batch
+INSERT_BATCH_SIZE = 100      # Batch size for INSERT
+```
+
+**How it works**:
+1. When you access a field on a recordset, Odoo loads that field for ALL records sharing the same `_prefetch_ids`
+2. Prefetch is per-model, not per-relation
+3. Related records are prefetched up to `PREFETCH_MAX`
+
+```python
+# GOOD: Automatic prefetch
+orders = self.search([('state', '=', 'done')])  # 1 query for orders
+for order in orders:
+    print(order.name)              # 1 query for all names (prefetched)
+    print(order.partner_id.name)   # 1 query for all partners (prefetched)
+# Total: ~3 queries regardless of recordset size
+```
+
+### Prefetch Groups
+
+Every recordset tracks `_prefetch_ids`. When you access a field, Odoo fetches it for every id in `_prefetch_ids` that is not yet cached.
+
+```python
+# All orders share the same prefetch group -> single SQL for related fields
+orders = self.search([])
+for order in orders:
+    # One query for partner_id batch, not one per order
+    print(order.partner_id.name)
+```
+
+### Controlling Prefetch Explicitly
+
+```python
+# Break a recordset out of its prefetch group (e.g. "expensive" records)
+big_attachments = attachments.with_prefetch()   # Empty prefetch -> each access only hits self
+
+# Force a shared prefetch group between two unrelated recordsets
+a = self.browse(ids_a).with_prefetch(all_ids)
+b = self.browse(ids_b).with_prefetch(all_ids)
+
+# Disable auto-prefetch of companion fields when fetching one field
+records.with_context(prefetch_fields=False).read(['name'])
+```
+
+`with_prefetch()` and `_prefetch_ids` live on `BaseModel` in `odoo/models.py`.
+
+---
+
+## N+1 Query Prevention
+
+### Pattern 1: Search Inside Loop (BAD)
+
+```python
+# BAD: N+1 queries
+for order in orders:
+    payments = self.env['payment.transaction'].search([
+        ('order_id', '=', order.id)
+    ])
+    order.payment_count = len(payments)
+# Result: 1 + N queries
+
+# GOOD: single IN query + read_group for counting
+groups = self.env['payment.transaction'].read_group(
+    [('order_id', 'in', orders.ids)],
+    fields=['order_id'],
+    groupby=['order_id'],
+)
+counts = {g['order_id'][0]: g['order_id_count'] for g in groups}
+for order in orders:
+    order.payment_count = counts.get(order.id, 0)
+# Result: 1 query
+```
+
+### Pattern 2: One2many Traversal
+
+```python
+# GOOD: mapped() + automatic prefetch
+orders = self.search([('state', '=', 'done')])
+for order in orders:
+    for line in order.line_ids:
+        print(line.product_id.name)
+# ~3 queries (orders, lines, products)
+
+# BETTER when you only need a few scalar fields
+lines_data = orders.mapped('line_ids').read(['product_id', 'quantity'])
+```
+
+### Pattern 3: Computed Field with Related Access
+
+```python
+# BAD: missing dependency -> query per record
+@api.depends('partner_id')
+def _compute_partner_email(self):
+    for order in self:
+        order.partner_email = order.partner_id.email  # N queries
+
+# GOOD: add dotted dependency -> single batched fetch
+@api.depends('partner_id', 'partner_id.email')
+def _compute_partner_email(self):
+    for order in self:
+        order.partner_email = order.partner_id.email
+```
+
+### Pattern 4: Conditional Computation
+
+```python
+# BAD: field access on single record forces fetch
+for order in orders:
+    if order.partner_id.customer_rank > 0:
+        order.is_customer = True
+
+# GOOD: filtered() uses cached prefetch data
+customers = orders.filtered(lambda o: o.partner_id.customer_rank > 0)
+customers.is_customer = True
+```
+
+### Pattern 5: `exists()` vs `search()` for Existence
+
+```python
+# BAD: fetches up to millions of rows
+if self.search([('state', '=', 'done')]):
+    ...
+
+# GOOD: limit=1
+if self.search([('state', '=', 'done')], limit=1):
+    ...
+
+# GOOD: search_count when you need the number
+count = self.search_count([('state', '=', 'done')])
+```
+
+---
+
+## Batch Operations
+
+### Batch Create (Odoo 16)
+
+Odoo 16 supports batch `create()` via a list of dicts (processed in chunks of `INSERT_BATCH_SIZE = 100`).
+
+```python
+# GOOD: batch create
+records = self.create([
+    {'name': f'Record {i}', 'state': 'draft'}
+    for i in range(100)
+])
+# Internal INSERTs chunked by INSERT_BATCH_SIZE
+
+# BAD: create in loop
+for i in range(100):
+    self.create({'name': f'Record {i}'})
+# 100 INSERT statements and 100 compute rounds
+```
+
+### Batch Write
+
+```python
+# GOOD: recordset write -> single UPDATE
+self.search([('state', '=', 'draft')]).write({'state': 'cancel'})
+
+# BAD: loop write
+for order in self.search([('state', '=', 'draft')]):
+    order.write({'state': 'cancel'})
+```
+
+### Batch Unlink
+
+```python
+# GOOD: recordset unlink -> single DELETE
+self.search([('state', '=', 'cancel')]).unlink()
+
+# BAD: loop unlink
+for order in self.search([('state', '=', 'cancel')]):
+    order.unlink()
+```
+
+### Chunked Processing for Large Datasets
+
+```python
+from odoo.tools import split_every
+
+def process_all(self):
+    ids = self.search([('to_process', '=', True)]).ids
+    for chunk_ids in split_every(500, ids):
+        records = self.browse(chunk_ids)
+        records._do_process()
+        # Commit between chunks to release locks on long jobs (cron only!)
+        self.env.cr.commit()
+```
+
+---
+
+## Field Selection Optimization
+
+### `search_read` when you need dicts, not recordsets
+
+```python
+# GOOD
+data = self.search_read(
+    [('state', '=', 'done')],
+    ['name', 'amount_total', 'date'],
+)
+# [{'id': 1, 'name': ..., 'amount_total': ..., 'date': ...}, ...]
+
+# SLOWER
+records = self.search([('state', '=', 'done')])
+data = records.read(['name', 'amount_total', 'date'])
+```
+
+### `read_group()` for Aggregations (Odoo 16 public API)
+
+In **Odoo 16**, the public, stable API for aggregation is `read_group()`. It returns a list of dicts including `__domain` / `__context` metadata and supports lazy grouping. `_read_group()` exists in core, but for business code and user-facing guidance, `read_group()` is the conservative choice.
+
+```python
+# GOOD: read_group() - Odoo 16 public API
+results = self.read_group(
+    domain=[('state', '=', 'done')],
+    fields=['amount_total:sum'],
+    groupby=['partner_id'],
+    lazy=True,
+)
+# [{
+#     'partner_id': (42, 'ACME'),
+#     'partner_id_count': 5,
+#     'amount_total': 1234.0,
+#     '__domain': [...],
+#     '__context': {...},
+# }, ...]
+
+for row in results:
+    partner_id, partner_name = row['partner_id'] or (False, '')
+    print(f"{partner_name}: {row['amount_total']} ({row['partner_id_count']} orders)")
+```
+
+Multiple groupbys with `lazy=False`:
+
+```python
+results = self.read_group(
+    domain=[('state', '=', 'done')],
+    fields=['amount_total:sum'],
+    groupby=['partner_id', 'state'],
+    lazy=False,
+)
+# One dict per (partner_id, state) combination
+```
+
+### `_read_group()` (core method, handle with care)
+
+`_read_group()` is an internal helper used by core aggregation paths. If you encounter it while reading framework code, verify the exact Odoo 16 source before copying the call shape into custom code.
+
+| Feature | `read_group()` (public) | `_read_group()` (core) |
+|---------|-------------------------|------------------------|
+| Return type | List of dicts | List of tuples |
+| Metadata | `__domain`, `__context`, `__range` | None |
+| Lazy grouping | Yes (`lazy=True`) | No |
+| Empty group fill | Yes | No |
+| API style | `domain, fields, groupby` | Internal/core helper; verify against source |
+| Stability | Stable public API in v16 | Internal helper |
+
+### Load Parameter for `read`
+
+```python
+# Skip computed/non-stored fields
+records.read(['name', 'state'], load=None)
+
+# Classic read (default): includes name_get for many2one etc.
+records.read(['name', 'partner_id'], load='_classic_read')
+```
+
+### `bin_size` for Binary Fields
+
+```python
+# GOOD: returns file size instead of base64 content
+attachments.with_context(bin_size=True).read(['datas', 'name'])
+```
+
+### Disable `active_test`
+
+```python
+# Include archived records
+all_records = self.with_context(active_test=False).search([])
+```
+
+---
+
+## Compute Field Optimization
+
+### Store Expensive Computations
+
+```python
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    amount_total = fields.Monetary(
+        string='Total',
+        compute='_compute_amount_total',
+        store=True,           # Store so we can search / group / sort on it
+        compute_sudo=True,    # Compute as superuser for performance
+    )
+
+    @api.depends('line_ids.price_subtotal')
+    def _compute_amount_total(self):
+        for order in self:
+            order.amount_total = sum(order.line_ids.mapped('price_subtotal'))
+```
+
+### Precompute (Odoo 16)
+
+```python
+# precompute=True: evaluated at create-time before INSERT,
+# stored together with other fields -> 1 INSERT instead of INSERT + UPDATE.
+sequence = fields.Integer(
+    compute='_compute_sequence',
+    precompute=True,
+    store=True,
+)
+```
+
+**Warning**: do NOT `precompute=True` when the compute needs DB reads of records that may not exist yet (e.g. aggregations over children).
+
+### Avoid Recursive Dependencies
+
+```python
+# BAD: A depends on B, B depends on A -> infinite recompute
+@api.depends('field_b')
+def _compute_a(self): ...
+
+@api.depends('field_a')
+def _compute_b(self): ...
+
+# GOOD: both depend on a common base field
+@api.depends('amount')
+def _compute_tax(self):
+    for rec in self:
+        rec.tax = rec.amount * 0.1
+
+@api.depends('amount', 'tax')
+def _compute_total(self):
+    for rec in self:
+        rec.total = rec.amount + rec.tax
+```
+
+### Add Database Indexes on Searched Fields
+
+```python
+reference = fields.Char(index=True)       # B-tree index
+external_id = fields.Char(index='btree_not_null')  # Odoo 16: partial index
+```
+
+---
+
+## SQL Optimization
+
+### When to Use Direct SQL
+
+Use SQL for:
+- Complex aggregations with joins across many tables
+- Bulk data migration scripts
+- Heavy reports
+- Read-only analytics that would otherwise cost thousands of ORM queries
+
+Avoid SQL for writes - you lose compute/invalidation/tracking.
+
+### Primary pattern: `cr.execute()`
+
+The canonical v16 pattern is plain parameterized `cr.execute`:
+
+```python
+def get_statistics(self):
+    self.env.cr.execute("""
+        SELECT state,
+               COUNT(*)          AS count,
+               SUM(amount_total) AS total
+          FROM sale_order
+         WHERE create_date >= %s
+      GROUP BY state
+    """, (fields.Date.today(),))
+    return self.env.cr.dictfetchall()
+```
+
+**Always** use `%s` placeholders and pass a tuple of parameters. Never f-string user input into SQL.
+
+### Dynamic SQL: keep identifiers on a Python allowlist
+
+If a table or column name must vary, choose it from a fixed Python allowlist first, then keep values parameterized:
+
+```python
+ALLOWED_GROUP_COLUMNS = {
+    'state': 'state',
+    'salesperson': 'user_id',
+}
+
+def totals_by(self, group_key):
+    group_column = ALLOWED_GROUP_COLUMNS[group_key]
+    query = f"""
+        SELECT {group_column}, SUM(amount_total)
+          FROM sale_order
+         WHERE state = %s
+      GROUP BY {group_column}
+    """
+    self.env.cr.execute(query, ('done',))
+    return dict(self.env.cr.fetchall())
+```
+
+Here the f-string is used only to splice in allowlisted SQL identifiers; the data value still goes through `%s` parameter binding.
+
+Never pass raw user input straight into SQL identifiers. Resolve it to a known-safe column name in Python first.
+
+### Never SQL-Write Without a Reason
+
+```python
+# BAD: bypasses cache, compute, tracking, access rules
+self.env.cr.execute("UPDATE sale_order SET state='done' WHERE id IN %s", (tuple(ids),))
+
+# GOOD
+self.browse(ids).write({'state': 'done'})
+```
+
+### Flush Before Reading via SQL
+
+When you bypass the ORM with `cr.execute`, pending in-memory writes on the involved fields may not yet be in the database. Flush them manually:
+
+```python
+self.env['sale.order'].flush_model(['state', 'amount_total'])
+self.env.cr.execute("SELECT state, SUM(amount_total) FROM sale_order GROUP BY state")
+```
+
+`flush_model(fnames=None)` is defined on `BaseModel` in `odoo/models.py` (v16). Without arguments, it flushes every pending field for the model.
+
+---
+
+## Flush & Cache Control
+
+Odoo 16 uses deferred writes: ORM updates accumulate in the cache and are flushed to the database lazily.
+
+### `env.flush_all()` / `env.invalidate_all()`
+
+```python
+# Flush every pending computation and write for the current environment
+self.env.flush_all()
+
+# Drop the in-memory cache (flushes first by default)
+self.env.invalidate_all()
+self.env.invalidate_all(flush=False)  # discard cache without flushing (rare)
+```
+
+Defined in `odoo/api.py` on `Environment`.
+
+### Per-Model / Per-Recordset Flush
+
+```python
+# Flush all pending updates for a model
+self.env['sale.order'].flush_model()
+
+# Flush only a few fields
+self.env['sale.order'].flush_model(['state', 'amount_total'])
+```
+
+### When to Flush Manually
+
+- Before running `cr.execute` on columns you just wrote to
+- Before calling a stored procedure / trigger-dependent SQL
+- When calling a method that must see previous computed values that were stored
+
+```python
+orders.write({'state': 'done'})
+# Before a SQL report that reads sale_order.state, flush:
+self.env['sale.order'].flush_model(['state'])
+self.env.cr.execute("SELECT state, SUM(amount_total) FROM sale_order GROUP BY state")
+```
+
+### `sudo()` is Not Free
+
+`sudo()` returns a new env with `su=True`. Each call creates a new recordset with a fresh prefetch group. Calling it inside a loop kills prefetch:
+
+```python
+# BAD: new sudo env each iteration breaks prefetch
+for order in orders:
+    order.sudo().partner_id.name   # each partner fetched alone
+
+# GOOD: sudo once on the recordset
+for order in orders.sudo():
+    order.partner_id.name          # batched
+```
+
+### `with_context` Tricks
+
+```python
+# Skip mail.thread tracking on bulk updates (huge speedup for chatter-enabled models)
+records.with_context(tracking_disable=True).write({'state': 'done'})
+
+# Include archived
+all_records = self.with_context(active_test=False).search([])
+
+# Binary field size only (no base64 payload)
+atts.with_context(bin_size=True).read(['datas'])
+
+# Skip prefetching sibling fields when reading a single one
+rec.with_context(prefetch_fields=False).read(['name'])
+```
+
+---
+
+## Clean Code Performance Patterns
+
+### `mapped()` over list comprehensions
+
+```python
+# GOOD: field access via mapped()
+partner_ids = orders.mapped('partner_id.id')
+countries = orders.mapped('partner_id.country_id')   # dotted paths OK
+
+# GOOD: mapped() of a many2many returns deduplicated recordset
+all_tags = orders.mapped('tag_ids')
+```
+
+### `filtered()` before operations
+
+```python
+done = orders.filtered(lambda o: o.state == 'done')
+done.action_invoice_create()
+```
+
+For performance on large sets, use `filtered_domain` to reuse domain evaluation:
+
+```python
+done = orders.filtered_domain([('state', '=', 'done')])
+```
+
+### `sorted()` with key - or let the DB do it
+
+```python
+# Small sets: in-memory sort
+top = orders.sorted(key='amount_total', reverse=True)[:5]
+
+# Large sets: let PostgreSQL sort with an index
+top = self.search([], order='amount_total DESC', limit=5)
+```
+
+### Avoid Recomputation in Loops
+
+```python
+# BAD: each write triggers a recompute pass
+for order in orders:
+    order.write({'state': 'done'})
+
+# GOOD: single batch write, single recompute pass
+orders.write({'state': 'done'})
+```
+
+---
+
+## Profiling & Query Count
+
+### Counting queries in tests
+
+`BaseCase` records the query count on `self.cr.sql_log` when enabled, but the standard pattern is `assertQueryCount`:
+
+```python
+from odoo.tests.common import TransactionCase
+
+class TestPerf(TransactionCase):
+
+    def test_loop_is_constant_in_queries(self):
+        orders = self.env['sale.order'].search([], limit=20)
+
+        with self.assertQueryCount(3):  # no N, regardless of len(orders)
+            for o in orders:
+                o.partner_id.name
+```
+
+`assertQueryCount` is defined in `odoo/tests/common.py` and is the Odoo 16 standard assertion for regression-proofing N+1 bugs.
+
+### Profiling with `odoo.tools.profiler`
+
+```python
+from odoo.tools.profiler import profile
+
+@profile  # writes a profile log on each call
+def heavy_method(self):
+    ...
+```
+
+For interactive profiling, start Odoo with `--dev=all` and use the Developer Tools > Profile menu, which leverages `odoo/tools/profiler.py`.
+
+### SQL log via config
+
+Run Odoo with `--log-sql` (or `log_sql = True` in odoo.conf) to see every SQL statement. Combined with `--log-handler=odoo.sql_db:DEBUG` you get timings, useful for finding N+1 patterns in local dev.
+
+---
+
+## Performance Checklist
+
+- [ ] No `search()` inside loops
+- [ ] Use `mapped()` / `filtered()` instead of Python loops for field access/filter
+- [ ] Use `search_read()` when you only need dicts
+- [ ] Use `read_group()` for aggregations (v16 public API)
+- [ ] Store expensive computed fields with `store=True`
+- [ ] Add all dependencies (including dotted) to `@api.depends`
+- [ ] Use `with_context(bin_size=True)` for binary fields
+- [ ] Use `with_context(tracking_disable=True)` for bulk writes on mail.thread models
+- [ ] Batch `create` / `write` / `unlink` on recordsets
+- [ ] Add `index=True` on frequently filtered fields
+- [ ] Call `sudo()` once at the top, not inside loops
+- [ ] Flush before `cr.execute()` on pending fields
+- [ ] If SQL identifiers must vary, resolve them from a fixed Python allowlist
+- [ ] Don't SQL-write - let the ORM do it
+- [ ] Add `assertQueryCount` in tests to lock performance
+
+---
+
+## Common Performance Anti-Patterns
+
+### Anti-Pattern 1: Unbounded `search()`
+
+```python
+# BAD
+records = self.search([('state', '=', 'draft')])  # could be millions
+
+# GOOD
+records = self.search([('state', '=', 'draft')], limit=100)
+```
+
+### Anti-Pattern 2: Compute with search in loop
+
+```python
+# BAD: search per record
+@api.depends('order_id')
+def _compute_order_total(self):
+    for line in self:
+        line.order_total = self.search_count([('order_id', '=', line.order_id.id)])
+```
+
+### Anti-Pattern 3: Re-reading after write
+
+```python
+# BAD: useless cache invalidation
+orders.write({'state': 'done'})
+self.env.invalidate_all()
+for order in orders:
+    print(order.state)  # now re-fetches from DB
+
+# GOOD: trust the cache
+orders.write({'state': 'done'})
+for order in orders:
+    print(order.state)  # already up-to-date
+```
+
+### Anti-Pattern 4: `sudo()` inside a loop
+
+```python
+# BAD: breaks prefetch
+for order in orders:
+    order.sudo().partner_id.name
+
+# GOOD: sudo once
+for order in orders.sudo():
+    order.partner_id.name
+```
+
+### Anti-Pattern 5: Over-fetching
+
+```python
+# BAD
+records = self.search([('state', '=', 'done')])
+for r in records:
+    print(r.name)   # only name used, but all fields prefetched
+
+# GOOD
+for row in self.search_read([('state', '=', 'done')], ['name']):
+    print(row['name'])
+```
+
+---
+
+## Base Code Reference
+
+- `odoo/models.py` - `BaseModel`, `PREFETCH_MAX`, `INSERT_BATCH_SIZE`, `read_group`, `search_read`, `flush_model`
+- `odoo/fields.py` - field prefetch groups, `_prefetch_ids`, `with_prefetch`
+- `odoo/api.py` - `Environment.flush_all`, `Environment.invalidate_all`
+- `odoo/tools/profiler.py` - `@profile` decorator
+- `odoo/tests/common.py` - `assertQueryCount`
+- `odoo/osv/expression.py` - domain-to-SQL translator

--- a/skills/odoo-16.0/references/odoo-16-reports-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-reports-guide.md
@@ -1,0 +1,893 @@
+---
+name: odoo-16-reports
+description: Complete reference for Odoo 16 QWeb reports covering PDF/HTML/Text reports, report templates, paper formats, external/internal layouts, barcodes, translatable reports, multi-company, and custom fonts.
+globs: "**/*.{py,xml}"
+topics:
+  - QWeb reports (qweb-pdf, qweb-html, qweb-text)
+  - ir.actions.report fields
+  - report.paperformat model
+  - t-call layouts (web.external_layout, web.internal_layout)
+  - Custom reports with _get_report_values
+  - Translatable reports (t-lang)
+  - Barcodes (/report/barcode route)
+  - Multi-company and external_report_layout_id
+  - Custom fonts in reports
+when_to_use:
+  - Creating PDF / HTML / text reports for models
+  - Designing report templates with standard or custom layouts
+  - Defining custom paper formats
+  - Adding barcodes or QR codes to reports
+  - Writing translatable reports
+  - Adding custom fonts
+---
+
+# Odoo 16 Reports Guide
+
+Complete reference for Odoo 16 QWeb reports: PDF, HTML, and text reports rendered through wkhtmltopdf or directly.
+
+## Table of Contents
+
+1. [Report Basics](#report-basics)
+2. [`ir.actions.report` Fields](#iractionsreport-fields)
+3. [Report Templates](#report-templates)
+4. [Layouts (`t-call`)](#layouts-t-call)
+5. [Paper Formats](#paper-formats)
+6. [Custom Reports (`_get_report_values`)](#custom-reports-_get_report_values)
+7. [Translatable Reports](#translatable-reports)
+8. [Barcodes](#barcodes)
+9. [Multi-Company Reports](#multi-company-reports)
+10. [Custom Fonts](#custom-fonts)
+11. [Debugging Reports](#debugging-reports)
+12. [Quick Reference](#quick-reference)
+
+---
+
+## Report Basics
+
+### What a QWeb Report Is
+
+A QWeb report in Odoo 16 is the combination of:
+
+1. An **`ir.actions.report` record** — the action that users trigger; configures the model, template, paper format, output type.
+2. A **QWeb template** (`ir.ui.view`, usually declared with `<template id="...">`) — the HTML markup rendered for each record.
+3. Optionally a Python **`AbstractModel`** named `report.<module>.<template_name>` whose `_get_report_values(docids, data)` feeds extra values to the template.
+
+### Report Types (`report_type`)
+
+| Value | Output | How |
+|-------|--------|-----|
+| `qweb-pdf` | PDF | Renders HTML + runs through `wkhtmltopdf` |
+| `qweb-html` | HTML | Served directly (useful for previews and debugging) |
+| `qweb-text` | Plain text | Renders QWeb and returns the text (used for POS tickets, email templates, etc.) |
+
+Defined in `odoo/addons/base/models/ir_actions_report.py`:
+
+```python
+report_type = fields.Selection([
+    ('qweb-html', 'HTML'),
+    ('qweb-pdf', 'PDF'),
+    ('qweb-text', 'Text'),
+], required=True, default='qweb-pdf')
+```
+
+### Declaring a Report: The `<report>` Shortcut
+
+The `<report>` tag expands to an `ir.actions.report` record. It does NOT create the template — you still write the `<template>` yourself.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Action -->
+    <report
+        id="action_report_invoice"
+        string="Invoice"
+        model="account.move"
+        report_type="qweb-pdf"
+        name="my_module.report_invoice_document"
+        file="my_module.report_invoice"
+        print_report_name="'Invoice - %s' % (object.name or 'draft')"
+        attachment="'Invoice-%s.pdf' % (object.name)"
+        attachment_use="True"
+    />
+
+    <!-- Template (declared separately) -->
+    <template id="report_invoice_document">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <h2>Invoice <span t-field="o.name"/></h2>
+                        <p>Partner: <span t-field="o.partner_id.name"/></p>
+                        <p>Amount:
+                            <span t-field="o.amount_total"
+                                  t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                        </p>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>
+```
+
+### Explicit Form (No Shortcut)
+
+```xml
+<record id="action_report_invoice" model="ir.actions.report">
+    <field name="name">Invoice</field>
+    <field name="model">account.move</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">my_module.report_invoice_document</field>
+    <field name="report_file">my_module.report_invoice</field>
+    <field name="binding_model_id" ref="account.model_account_move"/>
+    <field name="binding_type">report</field>
+    <field name="paperformat_id" ref="base.paperformat_euro"/>
+</record>
+```
+
+### Menu / Print Menu Binding
+
+Setting `binding_model_id` and `binding_type="report"` makes the action appear in that model's "Print" menu in the back-office UI.
+
+---
+
+## `ir.actions.report` Fields
+
+All fields, verified from `odoo/addons/base/models/ir_actions_report.py`:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `name` | Char | Human-readable name (also shown in the Print menu) |
+| `model` | Char | Target model name (e.g. `"account.move"`) — REQUIRED |
+| `report_type` | Selection | `qweb-html` / `qweb-pdf` / `qweb-text` |
+| `report_name` | Char | XML id of the QWeb template (`module.template`) — REQUIRED |
+| `report_file` | Char | Hint for the main template file (optional) |
+| `print_report_name` | Char | Python expression producing the download filename; has `object` (current record) and `time` in scope |
+| `attachment` | Char | Python expression for an attachment filename; when set, the rendered PDF is saved as an `ir.attachment` on the record |
+| `attachment_use` | Boolean | If True, reuse the stored attachment on subsequent prints (validated invoices, etc.) |
+| `paperformat_id` | Many2one | `report.paperformat`; falls back to `company.paperformat_id`, then `base.paperformat_euro` |
+| `groups_id` | Many2many | Groups allowed to run the report |
+| `multi` | Boolean | If True, hide on single-record form views |
+| `binding_model_id` / `binding_type` | — | Attach to a model's action menu |
+
+### `attachment` vs `attachment_use`
+
+Use both together to render-once, reprint-from-store:
+
+```xml
+<field name="attachment">'Invoice-%s.pdf' % object.name</field>
+<field name="attachment_use" eval="True"/>
+```
+
+Only rendered reports with a filled `attachment` expression are stored (typically after the record reaches a non-draft state — check `print_report_name` vs `attachment` expressions in standard modules for inspiration).
+
+### `print_report_name` Examples
+
+```xml
+<field name="print_report_name">'Invoice - %s' % (object.name or 'Draft')</field>
+<field name="print_report_name">'SO-%s-%s' % (object.name, object.state)</field>
+<field name="print_report_name">
+    'BOM-%s-%s' % (object.product_tmpl_id.name or 'ref', time.strftime('%Y%m%d'))
+</field>
+```
+
+Variables available: `object` (the current record) and `time` (the Python `time` module).
+
+---
+
+## Report Templates
+
+### Minimal Skeleton
+
+```xml
+<template id="report_my_document">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <!-- Your content -->
+                    <h2 t-field="o.name"/>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+Structure in words:
+
+- `web.html_container` sets up `<html><head>` and includes report assets.
+- `web.external_layout` wraps content with the company's header and footer.
+- `div.page` is the per-page content (important for wkhtmltopdf page breaks).
+
+### Variables Available in the Template
+
+| Variable | Description |
+|----------|-------------|
+| `docs` | Recordset of the documents being rendered |
+| `doc_ids` | List of IDs |
+| `doc_model` | Model name string |
+| `user` | `res.users` — the user printing the report |
+| `res_company` | `res.company` — the user's current company |
+| `company` | Automatically set by `web.external_layout` (multi-company aware) |
+| `time` | Python `time` module |
+| `context_timestamp` | Converts a UTC datetime to the user timezone |
+| `web_base_url` | Base URL of the server |
+
+Custom `_get_report_values` can add more (see below).
+
+### Core QWeb Directives (Reports)
+
+```xml
+<!-- Loop -->
+<t t-foreach="docs" t-as="o">
+    ...
+</t>
+
+<!-- Condition -->
+<p t-if="o.state == 'draft'">DRAFT</p>
+<p t-elif="o.state == 'posted'">Posted</p>
+<p t-else="">Other state</p>
+
+<!-- Field rendering (smart: dates, currency, etc.) -->
+<span t-field="o.date_order"/>
+<span t-field="o.amount_total"
+      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+
+<!-- Escape a computed value -->
+<span t-esc="o.name"/>
+<span t-esc="'%s items' % len(o.line_ids)"/>
+
+<!-- Raw (escape off) -->
+<div t-out="o.note"/>
+
+<!-- Call a template -->
+<t t-call="web.external_layout">...</t>
+
+<!-- Set a local var -->
+<t t-set="subtotal" t-value="sum(l.price_subtotal for l in o.order_line)"/>
+
+<!-- Attribute binding -->
+<div t-att-class="'text-danger' if o.state == 'cancel' else 'text-success'"/>
+<a t-attf-href="{{ web_base_url }}/web#id={{ o.id }}&amp;model={{ doc_model }}">Open</a>
+
+<!-- Translation language (must be on t-call) -->
+<t t-call="my_module.body" t-lang="o.partner_id.lang"/>
+```
+
+### `t-field` Widget Options
+
+`t-options` passes a dict to the underlying field formatter:
+
+```xml
+<!-- Monetary -->
+<span t-field="o.amount_total"
+      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+
+<!-- Date -->
+<span t-field="o.date_order"
+      t-options='{"format": "yyyy-MM-dd"}'/>
+
+<!-- Image (binary field) -->
+<img t-att-src="image_data_uri(o.image_1920)"/>
+
+<!-- Selection (uses the label, not the key) -->
+<span t-field="o.state"/>
+
+<!-- Many2one (shows display_name) -->
+<span t-field="o.partner_id"/>
+
+<!-- HTML field -->
+<div t-field="o.note"/>
+```
+
+---
+
+## Layouts (`t-call`)
+
+Odoo 16 provides several layout templates in `addons/web/views/report_templates.xml`:
+
+| Template | Purpose |
+|----------|---------|
+| `web.html_container` | Top-level wrapper — always the first `t-call` |
+| `web.external_layout` | Outer report layout — header, footer, company branding (chosen by `company.external_report_layout_id`) |
+| `web.internal_layout` | Minimal layout for internal docs (no header/footer flourish) |
+| `web.external_layout_standard` | The default standard layout |
+| `web.external_layout_boxed`, `web.external_layout_bold`, `web.external_layout_striped` | Variants used when the company selects a different branding |
+| `web.minimal_layout` | Used by the PDF pipeline internally (don't call from your templates) |
+
+### Recipe: Report With Header/Footer
+
+```xml
+<template id="report_order_document">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h2>
+                        Order <span t-field="o.name"/>
+                    </h2>
+                    <p>
+                        <strong>Partner:</strong>
+                        <span t-field="o.partner_id"/>
+                    </p>
+                    <table class="table table-sm o_main_table">
+                        <thead>
+                            <tr>
+                                <th>Product</th>
+                                <th class="text-end">Quantity</th>
+                                <th class="text-end">Subtotal</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr t-foreach="o.order_line" t-as="line">
+                                <td><span t-field="line.product_id"/></td>
+                                <td class="text-end"><span t-field="line.product_uom_qty"/></td>
+                                <td class="text-end">
+                                    <span t-field="line.price_subtotal"
+                                          t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+### Recipe: Internal Layout
+
+```xml
+<template id="report_internal_checklist">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="web.internal_layout">
+                <div class="page">
+                    <h3>Checklist: <t t-esc="o.name"/></h3>
+                    <ul>
+                        <li t-foreach="o.check_ids" t-as="c" t-esc="c.name"/>
+                    </ul>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+---
+
+## Paper Formats
+
+`report.paperformat` is a small model declared with these key fields (see `odoo/addons/base/data/report_paperformat_data.xml` for defaults):
+
+| Field | Values / type | Notes |
+|-------|---------------|-------|
+| `name` | Char | Free-form label |
+| `default` | Boolean | Whether listed as default when picking |
+| `format` | Selection | `A0`..`A10`, `B0`..`B10`, `Letter`, `Legal`, `Tabloid`, `custom` |
+| `page_height` / `page_width` | Integer (mm) | Only used when `format='custom'` |
+| `orientation` | `Portrait` / `Landscape` | |
+| `margin_top/bottom/left/right` | Integer (mm) | |
+| `header_spacing` | Integer (mm) | Space reserved for header |
+| `header_line` | Boolean | Draw a separator line under the header |
+| `dpi` | Integer | Output DPI (default 90) |
+| `disable_shrinking` | Boolean | Add wkhtmltopdf's `--disable-smart-shrinking` |
+
+### Standard A4 Format (Odoo provides this)
+
+From `odoo/addons/base/data/report_paperformat_data.xml`:
+
+```xml
+<record id="paperformat_euro" model="report.paperformat">
+    <field name="name">A4</field>
+    <field name="default" eval="True"/>
+    <field name="format">A4</field>
+    <field name="page_height">0</field>
+    <field name="page_width">0</field>
+    <field name="orientation">Portrait</field>
+    <field name="margin_top">40</field>
+    <field name="margin_bottom">32</field>
+    <field name="margin_left">7</field>
+    <field name="margin_right">7</field>
+    <field name="header_line" eval="False"/>
+    <field name="header_spacing">35</field>
+    <field name="dpi">90</field>
+</record>
+```
+
+Available XML IDs you can reference: `base.paperformat_euro` (A4), `base.paperformat_us` (Letter).
+
+### Custom Paper Format
+
+```xml
+<record id="paperformat_shipping_label" model="report.paperformat">
+    <field name="name">Shipping Label 100x150</field>
+    <field name="default" eval="False"/>
+    <field name="format">custom</field>
+    <field name="page_height">150</field>
+    <field name="page_width">100</field>
+    <field name="orientation">Portrait</field>
+    <field name="margin_top">2</field>
+    <field name="margin_bottom">2</field>
+    <field name="margin_left">2</field>
+    <field name="margin_right">2</field>
+    <field name="header_line" eval="False"/>
+    <field name="header_spacing">2</field>
+    <field name="dpi">200</field>
+</record>
+```
+
+### Attaching a Paper Format to a Report
+
+```xml
+<record id="action_report_shipping_label" model="ir.actions.report">
+    <field name="name">Shipping Label</field>
+    <field name="model">stock.picking</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">my_module.report_shipping_label</field>
+    <field name="paperformat_id" ref="my_module.paperformat_shipping_label"/>
+</record>
+```
+
+Resolution order used by `ir.actions.report.get_paperformat()`:
+1. `report.paperformat_id` on the action.
+2. `env.company.paperformat_id`.
+3. Fallback to `base.paperformat_euro`.
+
+---
+
+## Custom Reports (`_get_report_values`)
+
+When you need more than `docs` (pre-computed totals, grouped data, related records fetched in bulk), define an `AbstractModel` named `report.<module>.<template_name>`.
+
+```python
+# my_module/report/report_invoice.py
+from odoo import api, models
+
+
+class ReportInvoice(models.AbstractModel):
+    _name = 'report.my_module.report_invoice_document'
+    _description = 'Invoice Report'
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        docs = self.env['account.move'].browse(docids)
+
+        # Pre-compute everything you don't want to loop in QWeb
+        totals_by_invoice = {
+            move.id: {
+                'line_count': len(move.invoice_line_ids),
+                'subtotal': sum(l.price_subtotal for l in move.invoice_line_ids),
+                'tax_total': move.amount_tax,
+            }
+            for move in docs
+        }
+
+        return {
+            'doc_ids': docids,
+            'doc_model': 'account.move',
+            'docs': docs,
+            'data': data,
+            'totals': totals_by_invoice,
+        }
+```
+
+Register in `__init__.py`:
+
+```python
+# my_module/report/__init__.py
+from . import report_invoice
+
+# my_module/__init__.py
+from . import report
+```
+
+Use the extra values in the template:
+
+```xml
+<template id="report_invoice_document">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h2>Invoice <span t-field="o.name"/></h2>
+                    <p>Lines: <t t-esc="totals[o.id]['line_count']"/></p>
+                    <p>Subtotal:
+                        <span t-esc="totals[o.id]['subtotal']"
+                              t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                    </p>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+Important: the AbstractModel name MUST be `report.<report_name>` where `<report_name>` matches the `report_name` field on `ir.actions.report`.
+
+---
+
+## Translatable Reports
+
+`t-lang` switches the translation context for a `t-call` — it is the ONLY supported way to render part of a report in another language.
+
+### Two-Template Pattern (Standard)
+
+```xml
+<!-- Wrapper: loops, delegates to the document template per language -->
+<template id="report_saleorder">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="my_module.report_saleorder_document" t-lang="o.partner_id.lang or user.lang"/>
+        </t>
+    </t>
+</template>
+
+<!-- Document: rendered in the requested language -->
+<template id="report_saleorder_document">
+    <!-- Re-browse in the target language so translatable fields follow -->
+    <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)"/>
+    <t t-call="web.external_layout">
+        <div class="page">
+            <h2>Order <span t-field="o.name"/></h2>
+            <p>Status: <span t-field="o.state"/></p>  <!-- translated Selection label -->
+        </div>
+    </t>
+</template>
+```
+
+Key rules:
+
+- `t-lang="<python expr>"` only works on a `t-call`.
+- Use `o.with_context(lang=...)` to re-browse the record so that translatable Char/Text/Selection values render in the right language.
+- Terms inside the template (static strings) must be extracted into `.po` files like any other module content.
+
+### Header/Footer in a Different Language
+
+The wkhtmltopdf rendering pipeline sets `t-lang` on the `web.external_layout` call itself in some patterns — you can force the header and footer into a fixed language (e.g. English) while keeping the body in the partner's language:
+
+```xml
+<template id="report_invoice">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="web.external_layout" t-lang="'en_US'">
+                <div class="page">
+                    <!-- Re-browse body content in the partner's language -->
+                    <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)"/>
+                    <h2>Invoice <span t-field="o.name"/></h2>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+---
+
+## Barcodes
+
+Odoo serves barcode images through the controller route registered in `addons/web/controllers/report.py`:
+
+```python
+@http.route(['/report/barcode', '/report/barcode/<barcode_type>/<path:value>'],
+            type='http', auth="public")
+def report_barcode(self, barcode_type, value, **kwargs):
+    ...
+```
+
+So there are two valid URL shapes in Odoo 16.
+
+### Short Path Form (`/report/barcode/<type>/<value>`)
+
+```xml
+<!-- QR code -->
+<img t-att-src="'/report/barcode/QR/%s' % o.name"/>
+
+<!-- Code128 -->
+<img t-att-src="'/report/barcode/Code128/%s' % o.default_code"/>
+```
+
+### Query-String Form (Supports Sizing, Human-Readable Labels)
+
+```xml
+<img t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % (
+    'Code128', o.name, 200, 50
+)"/>
+
+<img t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;humanreadable=1' % (
+    'EAN13', o.barcode or '0000000000000', 300, 100
+)"/>
+```
+
+In XML, remember to escape `&` as `&amp;`.
+
+### Supported Barcode Types (Odoo 16)
+
+From `ir.actions.report.barcode()`:
+
+- Linear: `Codabar`, `Code11`, `Code128`, `Code39`, `Extended39`, `Extended93`, `Standard39`, `Standard93`, `EAN8`, `EAN13`, `FIM`, `I2of5`, `ISBN`, `MSI`, `POSTNET`, `UPCA`, `USPS_4State`
+- 2D: `QR`, `DataMatrix`
+- Heuristic: `auto` (guesses from value length: 8 → EAN8, 13 → EAN13, else Code128)
+
+### Parameters (query string)
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `barcode_type` | string | — | One of the types above |
+| `value` | string | — | The data to encode |
+| `width` | int | 600 | Pixel width |
+| `height` | int | 100 | Pixel height |
+| `humanreadable` | 0 / 1 | 0 | Adds readable text under barcode |
+| `quiet` | 0 / 1 | 1 | White margins on sides |
+| `mask` | string | None | Mask for QR bills (e.g. Swiss QR) |
+| `barBorder` | int | 4 | QR border size |
+| `barLevel` | `L` / `M` / `Q` / `H` | `L` | QR error correction level |
+
+### Product-Barcode Recipe
+
+```xml
+<template id="report_product_label">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="p">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h3 t-field="p.name"/>
+                    <p>Ref: <span t-field="p.default_code"/></p>
+                    <img t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;humanreadable=1' % (
+                        'Code128',
+                        p.default_code or p.barcode or str(p.id),
+                        300, 80,
+                    )"/>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+---
+
+## Multi-Company Reports
+
+`web.external_layout` handles multi-company automatically:
+
+1. Prefer an explicit `company` variable (if your template sets one).
+2. Else the `company_id` passed through the render context.
+3. Else `o.company_id` if the current document has one.
+4. Else `res_company` (the user's active company).
+
+The layout variant used is read from `company.external_report_layout_id` (Standard, Boxed, Bold, Striped, Clean, etc.).
+
+For reports spanning documents from several companies, set `company` yourself inside the loop:
+
+```xml
+<template id="report_cross_company">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-set="company" t-value="o.company_id or res_company"/>
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h2 t-field="o.name"/>
+                    <p>From company: <span t-field="company.name"/></p>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+---
+
+## Custom Fonts
+
+To ship a custom font used by PDF reports:
+
+1. Drop the font files under `my_module/static/src/fonts/`.
+2. Declare them in `web.report_assets_common` (NOT `web.assets_backend`).
+3. Reference the font in QWeb or CSS.
+
+`my_module/static/src/scss/report_fonts.scss`:
+
+```scss
+@font-face {
+    font-family: "Inter";
+    src: url("/my_module/static/src/fonts/Inter-Regular.woff2") format("woff2");
+    font-weight: 400;
+}
+@font-face {
+    font-family: "Inter";
+    src: url("/my_module/static/src/fonts/Inter-Bold.woff2") format("woff2");
+    font-weight: 700;
+}
+
+.o_invoice_title {
+    font-family: "Inter", sans-serif;
+    font-weight: 700;
+    font-size: 28px;
+}
+```
+
+`my_module/__manifest__.py`:
+
+```python
+'assets': {
+    'web.report_assets_common': [
+        'my_module/static/src/scss/report_fonts.scss',
+    ],
+},
+```
+
+Use in a template:
+
+```xml
+<h1 class="o_invoice_title">Invoice <span t-field="o.name"/></h1>
+```
+
+Only SCSS/CSS included in `web.report_assets_common` is available to the PDF renderer; `web.assets_backend` is only loaded in the back-office UI.
+
+---
+
+## Debugging Reports
+
+### Preview the HTML
+
+With developer mode on, you can open:
+
+```
+/report/html/<report_name>/<doc_id>
+```
+
+For example:
+
+```
+/report/html/my_module.report_invoice_document/42
+```
+
+The HTML is rendered exactly as wkhtmltopdf will see it. Missing header/footer is expected here — they are injected by the PDF pipeline.
+
+### Preview the PDF
+
+```
+/report/pdf/<report_name>/<doc_id>
+```
+
+### Text Output
+
+```
+/report/text/<report_name>/<doc_id>
+```
+
+(Only meaningful for `report_type='qweb-text'`.)
+
+### Download Filename
+
+`print_report_name` controls the filename you see on download. It is a Python expression — double-check you escaped quotes in XML (`&apos;`, `&quot;`) when the expression uses them.
+
+### Common Pitfalls
+
+- **Blank PDF**: forgotten `web.html_container` wrapper, or the `web.external_layout` doesn't wrap a `div.page`.
+- **Styles missing in PDF**: SCSS added to `web.assets_backend` instead of `web.report_assets_common`.
+- **Report template not found**: `report_name` on the action doesn't match the `<template id="...">` (include module prefix).
+- **`object` undefined in `print_report_name`**: the expression is eval'd with `object` (single record) and `time`. Not `obj`, not `record`.
+- **Wkhtmltopdf too old**: Odoo 16 needs 0.12.x. Server log complains on startup if unsuitable.
+
+---
+
+## Quick Reference
+
+### Minimal Module Layout
+
+```
+my_module/
+├── __manifest__.py
+├── __init__.py
+├── models/
+│   └── ...
+├── report/
+│   ├── __init__.py
+│   ├── report_invoice.py              # AbstractModel (optional)
+│   ├── report_invoice_templates.xml   # <report> and <template>
+│   └── paperformat_data.xml           # Custom report.paperformat (optional)
+└── static/src/
+    ├── scss/
+    │   └── report_fonts.scss
+    └── fonts/
+        └── Inter-Regular.woff2
+```
+
+`__manifest__.py`:
+
+```python
+{
+    'name': 'My Module',
+    'version': '16.0.1.0.0',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'depends': ['base', 'web'],
+    'data': [
+        'report/paperformat_data.xml',
+        'report/report_invoice_templates.xml',
+    ],
+    'assets': {
+        'web.report_assets_common': [
+            'my_module/static/src/scss/report_fonts.scss',
+        ],
+    },
+}
+```
+
+### Report Action (Full Form)
+
+```xml
+<report
+    id="action_report_my_doc"
+    string="My Document"
+    model="my.model"
+    report_type="qweb-pdf"
+    name="my_module.report_my_doc_document"
+    file="my_module.report_my_doc"
+    print_report_name="'MyDoc-%s' % (object.name or 'draft')"
+    attachment="'MyDoc-%s.pdf' % object.name"
+    attachment_use="True"
+    paperformat_id="base.paperformat_euro"
+    groups_id="base.group_user"
+    binding_model_id="model_my_model"
+    binding_type="report"
+/>
+```
+
+### Template Skeleton
+
+```xml
+<template id="report_my_doc_document">
+    <t t-call="web.html_container">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <!-- Your content -->
+                </div>
+            </t>
+        </t>
+    </t>
+</template>
+```
+
+### Useful URLs
+
+| URL | Description |
+|-----|-------------|
+| `/report/html/<report_name>/<id>` | Render HTML preview |
+| `/report/pdf/<report_name>/<id>` | Download PDF |
+| `/report/text/<report_name>/<id>` | Text output |
+| `/report/barcode/<type>/<value>` | Barcode PNG (short form) |
+| `/report/barcode/?barcode_type=...&value=...&width=...&height=...&humanreadable=1` | Barcode PNG with options |
+
+### QWeb Cheat Sheet
+
+| Directive | Usage |
+|-----------|-------|
+| `t-call="web.html_container"` | Report wrapper (mandatory) |
+| `t-call="web.external_layout"` | Header + footer + branding |
+| `t-call="web.internal_layout"` | Minimal layout |
+| `t-foreach="docs" t-as="o"` | Iterate records |
+| `t-if / t-elif / t-else` | Conditionals |
+| `t-field="o.field"` | Smart render (formats dates, currencies, images) |
+| `t-esc="expr"` | Escape + render |
+| `t-out="expr"` | Escape-safe HTML render: outputs the raw string only when the value is a `markupsafe.Markup` instance, otherwise HTML-escapes like `t-esc`. Safe default for HTML fields (their values are already wrapped in `Markup`). Never feed it user input wrapped in `Markup` without sanitising first. |
+| `t-set="x" t-value="..."` | Local variable |
+| `t-options='{"widget": "monetary", "display_currency": o.currency_id}'` | Field widget options |
+| `t-lang="'en_US'"` | Translation language (on `t-call` only) |
+| `t-attf-href="{{ web_base_url }}/..."` | Templated attribute |
+
+---
+
+## Base Code Reference
+
+The APIs and templates documented here live in the Odoo 16 source:
+
+- `odoo/addons/base/models/ir_actions_report.py` — `ir.actions.report` model, `_render_qweb_pdf`, `_render_qweb_html`, `_render_qweb_text`, `barcode`, `get_paperformat`.
+- `odoo/addons/base/data/report_paperformat_data.xml` — default paper formats (`paperformat_euro`, `paperformat_us`, `paperformat_batch_deposit`).
+- `addons/web/views/report_templates.xml` — `web.html_container`, `web.external_layout`, `web.internal_layout`, `web.minimal_layout`, `web.external_layout_standard`, and the other branding variants.
+- `addons/web/controllers/report.py` — `/report/html/...`, `/report/pdf/...`, `/report/text/...`, `/report/barcode/...`, `/report/download`.

--- a/skills/odoo-16.0/references/odoo-16-security-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-security-guide.md
@@ -1,0 +1,764 @@
+---
+name: odoo-16-security
+description: Complete reference for Odoo 16 security covering access rights (ACL via ir.model.access.csv), record rules (ir.rule), user groups (res.groups with category_id), field-level permissions, multi-company, the _check_company_auto flag, sudo() / with_user(), check_access_rights / check_access_rule and common security pitfalls.
+globs: "**/*.{py,xml,csv}"
+topics:
+  - Access rights (ir.model.access.csv)
+  - Record rules (ir.rule)
+  - Field-level access (groups attribute)
+  - User groups (res.groups, category_id)
+  - Multi-company and _check_company_auto
+  - sudo() / with_user() / bypass patterns
+  - check_access_rights / check_access_rule
+  - Security pitfalls (SQL injection, XSS, eval)
+when_to_use:
+  - Configuring security for new models
+  - Setting up access rights CSV
+  - Creating record rules
+  - Preventing security vulnerabilities
+  - Understanding multi-company security
+  - Implementing field-level permissions
+---
+
+# Odoo 16 Security Guide
+
+Complete reference for Odoo 16 security: access rights, record rules, field access, groups, multi-company and common pitfalls.
+
+## Table of Contents
+
+1. [Security Overview](#security-overview)
+2. [User Groups](#user-groups)
+3. [Access Rights (ACL)](#access-rights-acl)
+4. [Record Rules](#record-rules)
+5. [Field-Level Access](#field-level-access)
+6. [Multi-Company](#multi-company)
+7. [sudo / with_user / bypass patterns](#sudo--with_user--bypass-patterns)
+8. [Access Checks in Code](#access-checks-in-code)
+9. [Security Pitfalls](#security-pitfalls)
+
+---
+
+## Security Overview
+
+### Two-Layer Security
+
+| Layer | Mechanism | Purpose |
+|-------|-----------|---------|
+| 1 | Access Rights (ACL) | Grants CRUD access on an **entire model** |
+| 2 | Record Rules | Restricts **which records** of the model a user can access |
+
+Both are linked to users through **groups** (`res.groups`). A user belongs to multiple groups and permissions are the union of them.
+
+### Access Control Flow
+
+```
+User operation (read/write/create/unlink)
+        |
+        v
+Is at least one of user's groups allowed by ir.model.access?
+   |-- no --> AccessError
+   |
+   v
+Apply ir.rule for (model, operation, user's groups):
+   - Global rules (no `groups`)         -> AND together  (all must match)
+   - Group rules (have `groups`)        -> OR together   (one match is enough)
+   - Final domain = (AND of globals) AND (OR of group rules)
+        |
+        v
+Does record match the final domain?
+   |-- no --> AccessError
+   |
+   v
+Access granted
+```
+
+### Bypass Rules
+
+- Superuser (`self.env.su`, OdooBot / `__system__`) bypasses record rules.
+- `sudo()` returns a recordset whose `env.su` is True.
+- `with_user(user)` switches the user but **does not** bypass anything.
+- ACLs are **not** bypassed by `sudo` alone - only by the superuser context (`sudo()` elevates to superuser).
+
+---
+
+## User Groups
+
+### res.groups
+
+Groups are the foundation of Odoo security. In Odoo 16, `res.groups` has `category_id` pointing at `ir.module.category` - there is no `privilege_id` (that was introduced in later versions).
+
+### Defining a Group
+
+```xml
+<!-- security/security_groups.xml -->
+<odoo>
+    <!-- Module category (optional, used for grouping in Settings > Users) -->
+    <record id="module_category_trip_management" model="ir.module.category">
+        <field name="name">Trip Management</field>
+        <field name="description">Manage business trips</field>
+        <field name="sequence">20</field>
+    </record>
+
+    <record id="group_trip_user" model="res.groups">
+        <field name="name">User</field>
+        <field name="category_id" ref="module_category_trip_management"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
+    <record id="group_trip_manager" model="res.groups">
+        <field name="name">Manager</field>
+        <field name="category_id" ref="module_category_trip_management"/>
+        <field name="implied_ids" eval="[(4, ref('my_module.group_trip_user'))]"/>
+    </record>
+</odoo>
+```
+
+### res.groups Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Display name |
+| `category_id` | Many2one on `ir.module.category` - groups appear in that app's section in user settings |
+| `implied_ids` | Other groups implied by this one (users get both) |
+| `users` | Many2many on `res.users` |
+| `model_access` | One2many on `ir.model.access` |
+| `rule_groups` | Many2many on `ir.rule` |
+| `menu_access` | Menus accessible to the group |
+| `view_access` | Views accessible to the group |
+| `comment` | Description |
+| `share` | True if this group is only for sharing (portal-like) |
+
+### Group Inheritance via `implied_ids`
+
+If `group_manager` has `implied_ids` pointing to `group_user`, every user in `group_manager` is automatically added to `group_user` too. Use this to build hierarchies:
+
+```
+group_manager  >>  group_user  >>  base.group_user  (internal user)
+```
+
+### Checking Groups in Code
+
+```python
+# Is current user in a group?
+if self.env.user.has_group('my_module.group_trip_manager'):
+    ...
+
+# Safer when called as another user - re-check with sudo if needed
+if self.env.user.sudo().has_group('base.group_system'):
+    ...
+
+# has_group respects implied_ids: a manager is also a user automatically
+```
+
+---
+
+## Access Rights (ACL)
+
+### ir.model.access - Model-Level Access
+
+Access rights grant CRUD operations on an entire model. They are normally declared via a CSV file.
+
+```
+my_module/
+  security/
+    ir.model.access.csv
+```
+
+### CSV Columns (Odoo 16)
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+```
+
+Note: Odoo 16 uses exactly these 8 columns. Do not include `active` or any other column unless you know it is supported.
+
+### Example `ir.model.access.csv`
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_business_trip_user,business.trip.user,model_business_trip,my_module.group_trip_user,1,1,1,0
+access_business_trip_manager,business.trip.manager,model_business_trip,my_module.group_trip_manager,1,1,1,1
+access_business_trip_portal,business.trip.portal,model_business_trip,base.group_portal,1,0,0,0
+access_business_expense_all,business.expense.all,model_business_expense,,1,0,0,0
+```
+
+### Fields Explained
+
+| Column | Description |
+|--------|-------------|
+| `id` | Unique external ID for this ACL row |
+| `name` | Human-readable label |
+| `model_id:id` | External ID of the `ir.model` row - convention is `model_<model_name_with_underscores>` |
+| `group_id:id` | External ID of the `res.groups` row; **empty means all users** (including portal/public) |
+| `perm_read` | `1` or `0` - allow read |
+| `perm_write` | `1` or `0` - allow write |
+| `perm_create` | `1` or `0` - allow create |
+| `perm_unlink` | `1` or `0` - allow unlink (delete) |
+
+### ACL Rules of Thumb
+
+- ACLs are **additive**: a user gets the union of CRUD flags from every matching group.
+- An **empty `group_id`** grants access to **everyone** (internal, portal, public). Use sparingly.
+- A model with **no ACL row** is inaccessible to everyone except the superuser.
+- Every non-abstract model needs at least one ACL row, otherwise module installation fails with a warning and RPC access is denied.
+
+### Model ID Naming Convention
+
+For a model with `_name = 'business.trip'`, the `ir.model` external ID is `model_business_trip` in the module that declares the model. When referencing a model declared in another module, prefix: `other_module.model_business_trip`.
+
+---
+
+## Record Rules
+
+### ir.rule - Record-Level Security
+
+Record rules filter which records of a model a given user can access.
+
+```xml
+<record id="trip_personal_rule" model="ir.rule">
+    <field name="name">Business Trip: own records</field>
+    <field name="model_id" ref="model_business_trip"/>
+    <field name="domain_force">[('user_id', '=', user.id)]</field>
+    <field name="groups" eval="[(4, ref('my_module.group_trip_user'))]"/>
+    <field name="perm_read" eval="True"/>
+    <field name="perm_write" eval="True"/>
+    <field name="perm_create" eval="True"/>
+    <field name="perm_unlink" eval="False"/>
+</record>
+```
+
+### ir.rule Fields (Odoo 16)
+
+| Field | Description |
+|-------|-------------|
+| `name` | Description of the rule |
+| `active` | Disable without deleting |
+| `model_id` | Many2one on `ir.model` |
+| `groups` | Many2many on `res.groups`; empty = global rule |
+| `domain_force` | **String containing a Python list literal** for the domain (not XML) |
+| `perm_read`, `perm_write`, `perm_create`, `perm_unlink` | When this rule applies |
+
+`domain_force` must be a plain string that evaluates to a domain list - e.g. `"[('user_id', '=', user.id)]"`. It is parsed with `safe_eval`.
+
+### Variables Available in `domain_force`
+
+| Variable | Description |
+|----------|-------------|
+| `user` | Current user record (singleton, accessed via `sudo()` context) |
+| `user.id` | Current user ID |
+| `user.partner_id` | Partner linked to user |
+| `user.company_id` | User's current main company |
+| `user.company_ids` | IDs of companies the user can access (legacy alias) |
+| `company_id` | Current allowed company (`self.env.company.id`) |
+| `company_ids` | List of IDs of allowed companies (`self.env.companies.ids`) |
+| `time` | Python `time` module |
+
+### Global vs Group Rules
+
+| Type | How they combine |
+|------|------------------|
+| **Global** (`groups` empty) | **AND** together - all global rules must match |
+| **Group** (has groups) | **OR** together (within matching groups) - any rule of a matching group is enough |
+| Combined | `(AND of globals) AND (OR of group rules that apply)` |
+
+Use global rules for company separation; use group rules to broaden access for managers vs. employees.
+
+### Classic Patterns
+
+#### Own records only (employees)
+
+```xml
+<record id="trip_user_rule" model="ir.rule">
+    <field name="name">Trip: own records</field>
+    <field name="model_id" ref="model_business_trip"/>
+    <field name="domain_force">[('user_id', '=', user.id)]</field>
+    <field name="groups" eval="[(4, ref('my_module.group_trip_user'))]"/>
+</record>
+```
+
+#### All records (managers)
+
+```xml
+<record id="trip_manager_rule" model="ir.rule">
+    <field name="name">Trip: all records (manager)</field>
+    <field name="model_id" ref="model_business_trip"/>
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <field name="groups" eval="[(4, ref('my_module.group_trip_manager'))]"/>
+</record>
+```
+
+#### Portal users (own partner's records)
+
+```xml
+<record id="trip_portal_rule" model="ir.rule">
+    <field name="name">Trip: portal own</field>
+    <field name="model_id" ref="model_business_trip"/>
+    <field name="domain_force">[('partner_id', '=', user.partner_id.id)]</field>
+    <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+    <field name="perm_read" eval="True"/>
+    <field name="perm_write" eval="False"/>
+    <field name="perm_create" eval="False"/>
+    <field name="perm_unlink" eval="False"/>
+</record>
+```
+
+#### Time-sensitive access
+
+```xml
+<record id="archive_rule" model="ir.rule">
+    <field name="name">Only this year's records</field>
+    <field name="model_id" ref="model_business_trip"/>
+    <field name="domain_force">[('create_date', '&gt;=', time.strftime('%Y-01-01'))]</field>
+    <field name="groups" eval="[(4, ref('my_module.group_trip_user'))]"/>
+</record>
+```
+
+---
+
+## Field-Level Access
+
+### Restricting Fields to Groups
+
+The `groups=` attribute on a field limits who can read/write it. The field is hidden from `fields_get`, removed from views and raises `AccessError` on direct read/write for users who lack the group.
+
+```python
+class BusinessTrip(models.Model):
+    _name = 'business.trip'
+
+    name = fields.Char()                                       # all users
+    internal_notes = fields.Text(groups='base.group_user')     # internal users only
+    secret_code = fields.Char(groups='my_module.group_trip_manager')
+    salary = fields.Float(groups='base.group_system')          # admin only
+
+    # Multiple groups: comma-separated = OR
+    estimate = fields.Monetary(groups='base.group_user,base.group_portal')
+```
+
+### Field-Level Group Behaviour
+
+1. Field is automatically removed from `fields_get()` for users without any of the groups.
+2. Field is removed from **views** at load time (no placeholder rendered).
+3. Explicit `record.read(['secret_code'])` or `record.secret_code = x` raises `AccessError`.
+4. `record.with_context(prefetch_fields=False)` does NOT bypass the check.
+5. A computed stored field can still be computed for the database, but its value is hidden from the user.
+
+### Related Fields with Groups
+
+```python
+partner_email = fields.Char(related='partner_id.email', groups='base.group_user')
+```
+
+The field-level group on the related alias does not remove the check on the source field - but it does hide the field from users outside the group.
+
+---
+
+## Multi-Company
+
+### `_check_company_auto` Flag
+
+Set on a model to automatically validate that all Many2one fields pointing to company-scoped records have a compatible `company_id`.
+
+```python
+class SaleOrder(models.Model):
+    _name = 'sale.order'
+    _check_company_auto = True
+
+    company_id = fields.Many2one('res.company', default=lambda s: s.env.company, required=True)
+    partner_id = fields.Many2one('res.partner', check_company=True)
+    pricelist_id = fields.Many2one('product.pricelist', check_company=True)
+```
+
+On every `create()` / `write()`, Odoo calls `_check_company()` which validates all fields declared with `check_company=True` against the record's `company_id`. If the linked record belongs to another company (and isn't company-less), a `UserError` is raised.
+
+### Multi-Company Record Rule
+
+Always add a **global** rule for company filtering on any model with `company_id`:
+
+```xml
+<record id="business_trip_company_rule" model="ir.rule">
+    <field name="name">Business Trip: multi-company</field>
+    <field name="model_id" ref="model_business_trip"/>
+    <field name="domain_force">
+        ['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]
+    </field>
+</record>
+```
+
+Use `company_ids` (the user's **currently allowed** companies, honouring the company switcher) rather than `user.company_ids` (all companies the user can switch to) to respect the company switcher.
+
+### Recommended Field Definitions
+
+```python
+company_id = fields.Many2one(
+    'res.company', required=True, index=True,
+    default=lambda self: self.env.company,
+)
+
+# Always use check_company=True on Many2one to company-scoped records
+user_id = fields.Many2one('res.users', check_company=True)
+product_id = fields.Many2one('product.product', check_company=True)
+```
+
+---
+
+## sudo / with_user / bypass patterns
+
+### `sudo()` - Elevate to Superuser
+
+`sudo()` returns a new recordset whose environment runs as superuser. Record rules and field-level groups are bypassed; ACLs still work because the superuser has access to everything.
+
+```python
+# Read a field the current user can't see (e.g. internal audit log)
+internal_ref = record.sudo().internal_reference
+
+# Create a record the user isn't allowed to create directly
+self.env['mail.mail'].sudo().create({...})
+```
+
+Use sparingly - `sudo()` is a **bypass of permissions** and is a common source of vulnerabilities.
+
+### `with_user(user)` - Switch User Without Superuser
+
+Run code as a different user, **all permissions still enforced**.
+
+```python
+# Act on behalf of a specific user; AccessError will still fire if that user
+# lacks rights.
+res = self.with_user(self.env.ref('base.user_demo')).search([])
+```
+
+### `with_company(company)` - Switch Company Context
+
+```python
+records = self.with_company(other_company).search([])
+```
+
+### Typical `sudo()` Patterns
+
+```python
+# GOOD: sudo to read one safe related field, then keep processing as the real user
+partner_country = record.partner_id.sudo().country_id
+if partner_country.code == 'US':
+    record.action_apply_us_logic()          # still runs with ACL/rules
+
+# GOOD: manual gatekeeping before sudo - guarantees the caller is allowed
+def action_validate(self):
+    if not self.env.user.has_group('my_module.group_trip_manager'):
+        raise AccessError(_("Only Trip Managers can validate."))
+    self.sudo().write({'state': 'validated'})
+
+# BAD: blanket sudo() lets any user mutate any record
+def action_unsafe(self):
+    self.sudo().write({'active': False})   # No caller check - dangerous
+```
+
+### Checking Whether We Run as Superuser
+
+```python
+if self.env.su:
+    # We are running as superuser (record rules bypass)
+    ...
+```
+
+---
+
+## Access Checks in Code
+
+### `check_access_rights(operation, raise_exception=True)`
+
+Checks the ACL only - model-level permission.
+
+```python
+# Silent check
+can_read = self.env['business.trip'].check_access_rights('read', raise_exception=False)
+
+# Raising check
+self.env['business.trip'].check_access_rights('write')  # AccessError if denied
+```
+
+Valid operations: `'read'`, `'write'`, `'create'`, `'unlink'`.
+
+### `check_access_rule(operation)`
+
+Checks the record rules only on a specific recordset. Does nothing when running as superuser.
+
+```python
+# Will raise AccessError if any record in self is filtered out
+self.check_access_rule('write')
+```
+
+### Combined Check
+
+Typical "can this user do X on this record?" check:
+
+```python
+try:
+    self.check_access_rights('write')
+    self.check_access_rule('write')
+except AccessError:
+    raise UserError(_("You cannot modify this record."))
+```
+
+### Filtering by Rules (Non-Raising)
+
+```python
+# Returns the subset of self for which the operation is allowed
+allowed = self._filter_access_rules('read')
+```
+
+---
+
+## Security Pitfalls
+
+### 1. Public Methods Are Callable via RPC
+
+Any method that does **not** start with an underscore can be invoked by any authenticated user via JSON-RPC / XML-RPC - including internal users with minimal permissions. Always gate-keep:
+
+```python
+# BAD: any user can call this
+def action_force_done(self, new_state):
+    self.write({'state': new_state})
+
+# GOOD: private worker + controlled public entry point
+def action_force_done(self):
+    if not self.env.user.has_group('my_module.group_trip_manager'):
+        raise AccessError(_("Not allowed."))
+    self._set_state('done')
+
+def _set_state(self, state):
+    self.sudo().write({'state': state})
+```
+
+Note: In Odoo 16, keep internal-only helpers underscore-prefixed because the RPC layer does not expose underscore methods through JSON-RPC/XML-RPC. If you need a public button or service entry point, keep the permission checks on the public method and move the internal work into an underscore helper instead of relying on a decorator that does not exist in Odoo 16.
+
+### 2. Bypassing the ORM with Raw SQL
+
+Raw SQL bypasses ACLs, record rules, field-level access, translations and computed fields.
+
+```python
+# BAD
+self.env.cr.execute("SELECT id FROM business_trip WHERE user_id = %s", (user_id,))
+rows = self.env.cr.fetchall()
+
+# GOOD
+trips = self.env['business.trip'].search([('user_id', '=', user_id)])
+```
+
+When SQL is truly necessary, always use parameter substitution (`%s` placeholders) and post-filter the results through `browse().exists()` to re-apply access rules.
+
+### 3. SQL Injection
+
+```python
+# VERY BAD: concatenation/formatting opens SQL injection
+self.env.cr.execute("SELECT id FROM my_table WHERE name = '" + user_input + "'")
+
+# GOOD: parameterised query
+self.env.cr.execute("SELECT id FROM my_table WHERE name = %s", (user_input,))
+```
+
+### 4. XSS via `t-raw`
+
+```xml
+<!-- BAD: renders user content as HTML -->
+<div t-raw="message"/>
+
+<!-- GOOD -->
+<div t-esc="message"/>
+
+<!-- GOOD: explicit Markup for trusted structure -->
+<div t-out="rendered_body"/>     <!-- t-out auto-escapes but respects Markup -->
+```
+
+In Python:
+
+```python
+from markupsafe import Markup, escape
+
+# BAD: f-strings insert before escaping
+body = Markup(f"<p>{user_input}</p>")
+
+# GOOD: % formatting escapes the content
+body = Markup("<p>%s</p>") % user_input
+
+# GOOD: explicit escape
+body = Markup("<p>%s</p>") % escape(user_input)
+```
+
+### 5. Dangerous `eval`
+
+```python
+from ast import literal_eval
+from odoo.tools import safe_eval
+
+# VERY BAD
+domain = eval(self.filter_domain)
+
+# BAD (can still execute many functions with default globals)
+domain = safe_eval(self.filter_domain)
+
+# GOOD for simple literal expressions
+domain = literal_eval(self.filter_domain)
+```
+
+### 6. `getattr` on Arbitrary Field Names
+
+```python
+# BAD: can access private methods / attributes
+value = getattr(record, user_supplied_field)
+
+# GOOD: goes through the ORM, respects field-level groups
+value = record[user_supplied_field]   # AccessError if field is restricted
+```
+
+### 7. Skipping `check_company`
+
+Forgetting `check_company=True` on Many2one fields in multi-company models allows cross-company references, leaking data across companies.
+
+```python
+# BAD
+partner_id = fields.Many2one('res.partner')
+
+# GOOD
+partner_id = fields.Many2one('res.partner', check_company=True)
+```
+
+And set `_check_company_auto = True` on the model to enforce checks on every write/create.
+
+### 8. Overusing `sudo()`
+
+```python
+# BAD: wide open
+def action_archive(self):
+    for rec in self:
+        rec.sudo().write({'active': False})
+
+# GOOD: only elevate where required
+def action_archive(self):
+    self.check_access_rights('write')
+    self.check_access_rule('write')
+    self.sudo().write({'active': False})  # only elevate to update denormalised data
+```
+
+### 9. Validation Must Survive Race Conditions
+
+Use database constraints (`_sql_constraints`) or `@api.constrains` to enforce invariants, not just a pre-check in a method.
+
+```python
+_sql_constraints = [
+    ('amount_positive', 'CHECK (amount >= 0)', 'Amount must be positive'),
+]
+```
+
+### 10. Field Whitelisting on Public Endpoints
+
+HTTP controllers receiving user values must restrict which fields they forward to `write()`:
+
+```python
+ALLOWED_FIELDS = {'name', 'note', 'partner_id'}
+
+def _apply_form(self, record, values):
+    cleaned = {k: v for k, v in values.items() if k in ALLOWED_FIELDS}
+    record.sudo().write(cleaned)
+```
+
+---
+
+## Quick Reference
+
+### Security Checklist
+
+| Item | Done |
+|------|------|
+| Every non-abstract model has at least one `ir.model.access.csv` row | |
+| Groups declared with `category_id` on a module category | |
+| Record rules for own/all access per group | |
+| Global rule for `company_id` in multi-company models | |
+| `check_company=True` on Many2one + `_check_company_auto = True` | |
+| Sensitive fields restricted with `groups=` | |
+| Public methods gated with `has_group()` / `check_access_rights()` | |
+| No raw SQL with string concatenation | |
+| No `t-raw` with user-provided content | |
+| `sudo()` used sparingly, never to skip a permission the caller should have | |
+
+### Minimal Security Scaffold
+
+`security/security_groups.xml`:
+
+```xml
+<odoo>
+    <record id="module_category_my_module" model="ir.module.category">
+        <field name="name">My Module</field>
+        <field name="sequence">20</field>
+    </record>
+
+    <record id="group_my_user" model="res.groups">
+        <field name="name">User</field>
+        <field name="category_id" ref="module_category_my_module"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
+    <record id="group_my_manager" model="res.groups">
+        <field name="name">Manager</field>
+        <field name="category_id" ref="module_category_my_module"/>
+        <field name="implied_ids" eval="[(4, ref('my_module.group_my_user'))]"/>
+    </record>
+
+    <record id="my_model_user_rule" model="ir.rule">
+        <field name="name">My Model: own</field>
+        <field name="model_id" ref="model_my_model"/>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('my_module.group_my_user'))]"/>
+    </record>
+
+    <record id="my_model_manager_rule" model="ir.rule">
+        <field name="name">My Model: all</field>
+        <field name="model_id" ref="model_my_model"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('my_module.group_my_manager'))]"/>
+    </record>
+
+    <record id="my_model_company_rule" model="ir.rule">
+        <field name="name">My Model: multi-company</field>
+        <field name="model_id" ref="model_my_model"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+</odoo>
+```
+
+`security/ir.model.access.csv`:
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,my_module.group_my_user,1,1,1,0
+access_my_model_manager,my.model.manager,model_my_model,my_module.group_my_manager,1,1,1,1
+```
+
+Register both in the manifest (order matters - security XML must be loaded before the CSV uses its groups):
+
+```python
+# __manifest__.py
+{
+    'author': 'UncleCat',
+    'data': [
+        'security/security_groups.xml',
+        'security/ir.model.access.csv',
+        ...
+    ],
+}
+```
+
+---
+
+## Base Code Reference
+
+The guide is based on the Odoo 16 source tree. Reference files:
+
+| File | Contents |
+|------|----------|
+| `odoo/addons/base/models/ir_model.py` | `ir.model.access` implementation and CSV loader |
+| `odoo/addons/base/models/ir_rule.py` | `ir.rule` evaluation, `_eval_context`, global/group combination |
+| `odoo/addons/base/models/res_users.py` | `res.groups` (with `category_id`, `implied_ids`), `has_group`, `with_user` |
+| `odoo/models.py` | `check_access_rights`, `check_access_rule`, `_check_company`, `_check_company_auto` |
+| `odoo/api.py` | `Environment.su`, `sudo()`, `with_user()`, `with_company()` |
+
+**For more Odoo 16 guides, see [SKILL.md](../SKILL.md)**

--- a/skills/odoo-16.0/references/odoo-16-testing-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-testing-guide.md
@@ -1,0 +1,818 @@
+---
+name: odoo-16-testing
+description: Comprehensive guide for testing Odoo 16 modules - TransactionCase, SingleTransactionCase, HttpCase, ChromeBrowser tour tests, @tagged, @users, @mute_logger, @warmup, @standalone, @no_retry, mocking (self.patch / self.classPatch / self.startPatcher), assertQueryCount, form helpers (odoo.tests.common.Form, O2MProxy, M2MProxy) and running specific test tags.
+globs: "**/tests/**/*.py"
+topics:
+  - Test case types (TransactionCase, SingleTransactionCase, HttpCase)
+  - Test decorators (tagged, users, warmup, mute_logger, no_retry, standalone)
+  - Form testing (Form, O2MProxy, M2MProxy)
+  - Browser testing via ChromeBrowser and tours
+  - Mocking and patching
+  - Query-count assertions
+  - Tag selector syntax
+when_to_use:
+  - Writing module tests
+  - Adding regression coverage
+  - Testing UI flows or JS via tours
+  - Mocking external services
+  - Asserting query counts to catch N+1 regressions
+---
+
+# Odoo 16 Testing Guide
+
+Comprehensive guide to testing Odoo 16 modules: base test classes, decorators, mocking, form helpers, browser testing and best practices.
+
+## Table of Contents
+
+1. [Base Test Classes](#base-test-classes)
+2. [Test Decorators](#test-decorators)
+3. [Mocking and Patching](#mocking-and-patching)
+4. [Form Testing](#form-testing)
+5. [Browser Testing](#browser-testing)
+6. [Setup and Teardown](#setup-and-teardown)
+7. [Assert Helpers](#assert-helpers)
+8. [Test Data Helpers](#test-data-helpers)
+9. [Running Tests](#running-tests)
+10. [Best Practices](#best-practices)
+
+---
+
+## Base Test Classes
+
+### Location
+
+Test infrastructure for Odoo 16 lives in `odoo/tests/`:
+
+| File | Contents |
+|------|----------|
+| `common.py` | Base classes (`BaseCase`, `TransactionCase`, `SingleTransactionCase`, `HttpCase`, `ChromeBrowser`), decorators (`tagged`, `users`, `warmup`, `no_retry`, `standalone`) and helpers (`new_test_user`, `RecordCapturer`, `mute_logger`) |
+| `form.py` | `Form`, `O2MProxy`, `M2MProxy` - server-side form view simulation |
+| `case.py` | Lower-level `TestCase` |
+| `loader.py` | Test discovery |
+| `tag_selector.py` | `--test-tags` parser |
+
+`from odoo.tests import ...` re-exports everything from `odoo.tests.common` plus `Form`, `O2MProxy`, `M2MProxy` from `odoo.tests.form`.
+
+### Class Hierarchy
+
+```
+BaseCase
+  TransactionCase           (savepoint per test method)
+    HttpCase                (adds HTTP + ChromeBrowser)
+  SingleTransactionCase     (one transaction for the whole class)
+```
+
+### TransactionCase
+
+Each test method runs in its own **savepoint** on top of a class-wide transaction; nothing is committed and the savepoint is rolled back after each method. Use this for almost every test.
+
+```python
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestBusinessTrip(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env['res.partner'].create({'name': 'Alice'})
+        cls.trip = cls.env['business.trip'].create({
+            'name': 'Kickoff',
+            'partner_id': cls.partner.id,
+        })
+
+    def test_01_default_state(self):
+        self.assertEqual(self.trip.state, 'draft')
+
+    def test_02_confirm(self):
+        self.trip.action_confirm()
+        self.assertEqual(self.trip.state, 'confirmed')
+
+    def test_03_isolated(self):
+        # The write from test_02 has been rolled back
+        self.assertEqual(self.trip.state, 'draft')
+```
+
+Key points:
+
+- Data created in `setUpClass` is visible to every test but is rolled back at class teardown.
+- Mutations inside `test_X` are rolled back at the end of `test_X`.
+- `cls.env` is created in `setUpClass` and is the environment of the class-wide cursor.
+
+### SingleTransactionCase
+
+All tests in the class share the same transaction, which is rolled back at class teardown only. Tests see each other's writes, so ordering matters.
+
+```python
+from odoo.tests.common import SingleTransactionCase
+
+
+class TestStatefulFlow(SingleTransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.order = cls.env['sale.order'].create({'partner_id': cls.env.ref('base.res_partner_1').id})
+
+    def test_01_confirm(self):
+        self.order.action_confirm()
+        self.assertEqual(self.order.state, 'sale')
+
+    def test_02_invoice(self):
+        # test_01's change is still visible
+        self.assertEqual(self.order.state, 'sale')
+```
+
+Use when:
+
+- You want to reuse heavy state between tests (integration-style).
+- The savepoint overhead matters.
+
+### HttpCase
+
+Extends `TransactionCase` with HTTP access (`url_open`, `authenticate`) and a headless Chrome driver (`browser_js`, `start_tour`). Typically paired with `@tagged('post_install', '-at_install')` so the database is fully set up.
+
+```python
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestUI(HttpCase):
+    def test_homepage(self):
+        r = self.url_open('/web/login')
+        self.assertEqual(r.status_code, 200)
+
+    def test_admin_tour(self):
+        self.start_tour('/web', 'my_module_tour', login='admin')
+```
+
+Class attributes that can be tweaked:
+
+| Attribute | Default | Description |
+|-----------|---------|-------------|
+| `browser_size` | `'1366x768'` | Window size |
+| `touch_enabled` | `False` | Emulate touch events |
+| `allow_inherited_tests_method` | `False` | Allow running tests defined on a base class |
+
+### ChromeBrowser
+
+`HttpCase` lazily spins up a `ChromeBrowser` instance for `browser_js` / `start_tour`. It connects over the Chrome DevTools Protocol, captures console logs / errors, and fails the test on any `error:` message matching the internal filters. You rarely use it directly - prefer `start_tour`.
+
+---
+
+## Test Decorators
+
+### `@tagged`
+
+Tag classes (and, since the decorator is class-level, indirectly their test methods) for selective execution. Default tags on test classes are `'standard'` and `'at_install'`. Prefix with `-` to remove a tag.
+
+```python
+from odoo.tests.common import tagged, TransactionCase
+
+
+@tagged('post_install', '-at_install')
+class TestAfterInstall(TransactionCase):
+    ...
+
+
+@tagged('-standard', 'nightly')
+class TestNightly(TransactionCase):
+    """Run only when --test-tags=nightly is passed."""
+    ...
+
+
+@tagged('my_module', 'my_tag')
+class TestCustom(TransactionCase):
+    ...
+```
+
+Common built-in tags:
+
+| Tag | Meaning |
+|-----|---------|
+| `standard` | Default - included unless excluded |
+| `at_install` | Run during module install |
+| `post_install` | Run after install (use for HttpCase) |
+| `-at_install` | Remove default `at_install` |
+| `-standard` | Skip unless explicitly asked |
+
+### `@users`
+
+Run a test method once for each listed login. Login must exist. Inside the test, `self.env.user` and `self.uid` reflect the current user.
+
+```python
+from odoo.tests.common import users, TransactionCase
+
+
+class TestAccess(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['res.users'].create({
+            'name': 'Alice', 'login': 'alice', 'password': 'alicexxx',
+            'groups_id': [(6, 0, [cls.env.ref('base.group_user').id])],
+        })
+
+    @users('admin', 'alice')
+    def test_can_read(self):
+        self.assertTrue(self.env['business.trip'].search([]))
+```
+
+### `@warmup`
+
+Run the test **twice** - once to warm caches (results rolled back via savepoint), once for real. `self.warm` is `False` during warm-up and `True` during the real run. Use with `assertQueryCount` to get stable counts.
+
+```python
+from odoo.tests.common import warmup, TransactionCase
+
+
+class TestPerf(TransactionCase):
+    @warmup
+    def test_read_list(self):
+        with self.assertQueryCount(5):
+            self.env['business.trip'].search([]).mapped('name')
+```
+
+### `@mute_logger`
+
+Silence noisy loggers during a test (used as decorator or context manager).
+
+```python
+from odoo.tools import mute_logger
+
+
+class TestThings(TransactionCase):
+    @mute_logger('odoo.sql_db', 'odoo.addons.mail.models.mail_mail')
+    def test_creates_mail(self):
+        ...
+```
+
+### `@no_retry`
+
+Turn off the retry-on-serialization-failure wrapper (useful for tests that should fail deterministically).
+
+```python
+from odoo.tests.common import no_retry
+
+
+@no_retry
+class TestDeterministic(TransactionCase):
+    ...
+```
+
+### `@standalone`
+
+Mark a free function as a standalone test that can install / uninstall / upgrade modules (forbidden inside `TransactionCase`). Runs outside the normal test cycle.
+
+```python
+from odoo.tests.common import standalone
+
+
+@standalone('module_install')
+def test_install(env):
+    module = env['ir.module.module'].search([('name', '=', 'my_module')])
+    module.button_immediate_install()
+```
+
+### `freeze_time`
+
+Odoo 16 does **not** ship its own `freeze_time` in `odoo.tests.common`. Use the external `freezegun` package directly:
+
+```python
+from freezegun import freeze_time
+
+
+@freeze_time('2024-01-01 12:00:00')
+class TestDates(TransactionCase):
+    def test_today(self):
+        from odoo import fields
+        self.assertEqual(fields.Date.today(), fields.Date.from_string('2024-01-01'))
+```
+
+---
+
+## Mocking and Patching
+
+`BaseCase` exposes three helpers that register automatic cleanup with `addCleanup` / `addClassCleanup`, so patches are always unwound.
+
+### `self.patch(obj, attr, value)`
+
+```python
+def test_patch_method(self):
+    def replacement(self):
+        return 'mocked'
+
+    self.patch(type(self.env['business.trip']), 'compute_amount', replacement)
+    self.assertEqual(self.env['business.trip'].compute_amount(), 'mocked')
+```
+
+### `cls.classPatch(obj, attr, value)`
+
+Patch that lives for the whole class.
+
+```python
+@classmethod
+def setUpClass(cls):
+    super().setUpClass()
+
+    def always_ok(self):
+        return True
+
+    cls.classPatch(type(cls.env['business.trip']), '_validate', always_ok)
+```
+
+### `self.startPatcher(patcher)`
+
+Wrap any `unittest.mock._patch` and register its cleanup.
+
+```python
+from unittest.mock import patch
+
+
+def test_external_call(self):
+    mock_post = self.startPatcher(patch('requests.post'))
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {'ok': True}
+
+    result = self.env['my.model'].call_external()
+
+    mock_post.assert_called_once()
+    self.assertTrue(result)
+```
+
+### Common Mocking Patterns
+
+```python
+from unittest.mock import patch, mock_open
+
+
+# Mock an HTTP client
+def test_api(self):
+    with patch('requests.get') as mock_get:
+        mock_get.return_value.json.return_value = {'value': 42}
+        result = self.env['my.model'].fetch_value()
+        self.assertEqual(result, 42)
+
+
+# Mock file reads
+def test_read_config(self):
+    with patch('builtins.open', mock_open(read_data='KEY=VALUE')):
+        data = self.env['my.model']._read_config('/etc/nope')
+        self.assertEqual(data, {'KEY': 'VALUE'})
+```
+
+---
+
+## Form Testing
+
+`odoo.tests.common.Form` (re-exported from `odoo.tests.form`) simulates the client-side form view entirely server-side: onchange methods are triggered, defaults are applied, modifiers are evaluated, and x2many proxies manage inline editing.
+
+### Create Mode
+
+```python
+from odoo.tests.common import Form
+
+
+def test_create_via_form(self):
+    with Form(self.env['business.trip']) as f:
+        f.name = 'Berlin Workshop'
+        f.partner_id = self.partner
+    # f is saved on __exit__
+    trip = f.record
+    self.assertEqual(trip.name, 'Berlin Workshop')
+```
+
+### Edit Mode
+
+```python
+def test_edit_via_form(self):
+    with Form(self.trip) as f:
+        f.name = 'Updated'
+    self.assertEqual(self.trip.name, 'Updated')
+```
+
+### One2many with `O2MProxy`
+
+```python
+def test_one2many(self):
+    with Form(self.env['business.trip']) as f:
+        f.name = 'Trip A'
+
+        with f.expense_ids.new() as line:
+            line.description = 'Taxi'
+            line.amount = 25.0
+
+        with f.expense_ids.new() as line:
+            line.description = 'Hotel'
+            line.amount = 250.0
+
+        # Edit first line
+        with f.expense_ids.edit(0) as line:
+            line.amount = 30.0
+
+        # Remove second line
+        f.expense_ids.remove(1)
+
+    trip = f.record
+    self.assertEqual(len(trip.expense_ids), 1)
+    self.assertEqual(trip.expense_ids.amount, 30.0)
+```
+
+### Many2many with `M2MProxy`
+
+```python
+with Form(user) as f:
+    f.groups_id.add(self.env.ref('base.group_user'))
+    f.groups_id.remove(id=self.env.ref('base.group_portal').id)
+    f.groups_id.set(self.env['res.groups'].search([], limit=3))
+    f.groups_id.clear()
+```
+
+### Selecting a Specific View
+
+```python
+with Form(self.env['sale.order'], view='sale.view_order_form') as f:
+    ...
+```
+
+### Saving and Re-Opening
+
+```python
+f = Form(self.env['business.trip'])
+f.name = 'Trip'
+record = f.save()  # explicit save, returns the recordset
+
+# Re-open in edit mode later
+with Form(record) as f2:
+    f2.note = 'See you there'
+```
+
+---
+
+## Browser Testing
+
+### `url_open(path, data=None, method=None, timeout=None, headers=None, allow_redirects=True)`
+
+Issue an HTTP request to the running test server.
+
+```python
+def test_controller(self):
+    r = self.url_open('/my_module/api/ping')
+    self.assertEqual(r.status_code, 200)
+
+    r = self.url_open('/my_module/submit', data={'name': 'Bob'}, method='POST')
+    self.assertIn('thanks', r.text.lower())
+```
+
+### `authenticate(user, password)`
+
+Log in through the HTTP session (uses `requests.Session` under the hood).
+
+```python
+def test_as_admin(self):
+    self.authenticate('admin', 'admin')
+    r = self.url_open('/web/session/get_session_info')
+    self.assertEqual(r.status_code, 200)
+```
+
+### `browser_js(url_path, code, ready="", login=None, timeout=60, ...)`
+
+Execute arbitrary JavaScript in headless Chrome. The test succeeds when `code` resolves, fails on any unhandled console error.
+
+```python
+def test_some_js(self):
+    self.browser_js(
+        url_path='/web',
+        code="console.log('ok');",
+        ready="odoo.isReady",
+        login='admin',
+    )
+```
+
+### `start_tour(url_path, tour_name, step_delay=None, login=None, timeout=60, ...)`
+
+Run a JS tour defined in a module's `static/tests/tours/*.js`. Typical ergonomic wrapper.
+
+```python
+def test_checkout_tour(self):
+    self.start_tour('/shop', 'checkout_tour', login='demo')
+```
+
+Tours test files live under `static/tests/tours/`, registered in a QWeb assets bundle (usually `web.assets_tests`).
+
+---
+
+## Setup and Teardown
+
+### `setUpClass(cls)`
+
+Runs once before any test method. Use it to build shared fixtures with `cls.env`.
+
+```python
+@classmethod
+def setUpClass(cls):
+    super().setUpClass()
+    cls.manager = cls.env['res.users'].create({
+        'name': 'Manager', 'login': 'mgr', 'password': 'mgrxxxxx',
+        'groups_id': [(6, 0, [cls.env.ref('base.group_user').id])],
+    })
+    cls.trip = cls.env['business.trip'].create({'name': 'Demo'})
+```
+
+### `setUp(self)`
+
+Runs before each test method. Register cleanup with `self.addCleanup`.
+
+```python
+def setUp(self):
+    super().setUp()
+    self.addCleanup(self._cleanup_files)
+```
+
+### `tearDown(self)` / `tearDownClass(cls)`
+
+Usually not needed - `setUpClass` / `setUp` plus `addClassCleanup` / `addCleanup` cover most cases. If you override, call `super()`.
+
+### `addCleanup(callable, *args)` and `addClassCleanup(callable, *args)`
+
+Register a function to run on teardown, regardless of test outcome.
+
+```python
+temp = tempfile.mkdtemp()
+self.addCleanup(shutil.rmtree, temp)
+```
+
+---
+
+## Assert Helpers
+
+### `assertQueryCount(default=0, **counters)`
+
+Context manager that asserts the number of SQL queries executed. Use with `@warmup` to stabilise.
+
+```python
+@warmup
+def test_read_cost(self):
+    trips = self.env['business.trip'].search([])
+    with self.assertQueryCount(3):
+        trips.mapped('partner_id.name')
+```
+
+Multi-user form (paired with `@users`):
+
+```python
+@users('admin', 'demo')
+@warmup
+def test_multi_user_cost(self):
+    with self.assertQueryCount(admin=4, demo=6):
+        self.env['business.trip'].search([]).read(['name', 'state'])
+```
+
+The context manager logs a message when the real count is **lower** than expected (so you can tighten the assertion), and fails when it is **higher**.
+
+### `assertQueries(expected_queries, flush=True)`
+
+Assert that the exact sequence of queries was executed (partial string match per query).
+
+```python
+def test_order_of_queries(self):
+    with self.assertQueries([
+        'SELECT.*FROM business_trip',
+        'SELECT.*FROM res_partner',
+    ]):
+        self.env['business.trip'].search([]).mapped('partner_id.name')
+```
+
+### `assertRecordValues(records, expected)`
+
+Compare a recordset to a list of expected dicts (index-based).
+
+```python
+self.assertRecordValues(trips, [
+    {'name': 'Trip A', 'state': 'draft'},
+    {'name': 'Trip B', 'state': 'confirmed'},
+])
+```
+
+### `assertXMLEqual` / `assertHTMLEqual`
+
+Normalise whitespace/attribute order before comparison.
+
+### `assertTreesEqual(tree1, tree2)`
+
+Compare two `lxml` trees.
+
+### `assertURLEqual(url1, url2)`
+
+Tolerate missing scheme/host when comparing URLs.
+
+---
+
+## Test Data Helpers
+
+### `new_test_user(env, login, groups='base.group_user', context=None, **kwargs)`
+
+Create a user with sensible defaults (`name`, `email`, `password=login+'x'*N`) and the listed groups (comma-separated XML IDs).
+
+```python
+from odoo.tests.common import new_test_user
+
+
+@classmethod
+def setUpClass(cls):
+    super().setUpClass()
+    cls.trip_mgr = new_test_user(
+        cls.env, login='trip_mgr',
+        groups='base.group_user,my_module.group_trip_manager',
+        name='Trip Manager',
+    )
+```
+
+### `RecordCapturer(model, domain)`
+
+Capture records created (matching the domain) inside a block.
+
+```python
+from odoo.tests.common import RecordCapturer
+
+
+def test_capture(self):
+    with RecordCapturer(self.env['business.trip'], [('name', 'like', 'Auto-%')]) as cap:
+        self.env['business.trip'].create({'name': 'Auto-1'})
+        self.env['business.trip'].create({'name': 'Manual'})
+    self.assertEqual(len(cap.records), 1)
+```
+
+### `loaded_demo_data(env)`
+
+Returns `True` if demo data was loaded - use it to skip tests that rely on demo records.
+
+```python
+from odoo.tests.common import loaded_demo_data
+
+
+def test_needs_demo(self):
+    if not loaded_demo_data(self.env):
+        self.skipTest("Demo data not loaded")
+    ...
+```
+
+---
+
+## Running Tests
+
+### Basic Commands
+
+```bash
+# Install the module and run its at_install tests
+odoo-bin -d test_db -i my_module --test-enable --stop-after-init
+
+# Update and re-run tests
+odoo-bin -d test_db -u my_module --test-enable --stop-after-init
+
+# Run only post_install tests of my_module
+odoo-bin -d test_db --test-enable --test-tags=post_install -u my_module --stop-after-init
+```
+
+### `--test-tags` Syntax
+
+The selector supports `+include / -exclude` tokens separated by commas. Empty inclusion means *"everything tagged `standard`"*.
+
+```bash
+# Include a specific tag
+--test-tags=post_install
+
+# Exclude a tag
+--test-tags=-slow
+
+# Narrow to a module
+--test-tags=/my_module
+
+# Narrow to a class
+--test-tags=/my_module:TestBusinessTrip
+
+# Narrow to a method
+--test-tags=/my_module:TestBusinessTrip.test_02_confirm
+
+# Multiple filters
+--test-tags=post_install,-slow
+
+# Run only tests tagged `my_tag` (and exclude the standard default)
+--test-tags=-standard,my_tag
+```
+
+### Tips
+
+- HttpCase tests need the HTTP layer and demo data; tag them `post_install` so they run after module installation.
+- `--log-level=test` shows each test class and method as it runs.
+- Set `--log-handler=odoo.tests.common:DEBUG` to see query counts and browser events.
+- A test that modifies the registry must restore it (`self.registry.reset_changes()` / `addCleanup`).
+
+---
+
+## Best Practices
+
+### 1. Inherit `TransactionCase` by default
+
+Use `SingleTransactionCase` only when you really need shared mutable state, and `HttpCase` only for HTTP/browser tests.
+
+### 2. Always tag HttpCase
+
+```python
+@tagged('post_install', '-at_install')
+class TestUI(HttpCase):
+    ...
+```
+
+### 3. Keep `setUpClass` fast and deterministic
+
+Create the minimum fixtures there; tests should not rely on demo data unless they check for it.
+
+### 4. Use `Form` to exercise real UI flow
+
+Onchange, defaults, and modifiers are tested for free - this catches bugs that a raw `create()` misses.
+
+### 5. Pair `assertQueryCount` with `@warmup`
+
+Counts are unstable on cold caches. A warmup run flushes + invalidates, so the second run reflects the steady-state cost.
+
+### 6. Prefer `self.patch` / `self.startPatcher` over manual `patch().start()`
+
+They auto-unwind on cleanup and survive early test failures.
+
+### 7. Gate external integrations behind a tag
+
+```python
+@tagged('-standard', 'external')
+class TestPaymentGateway(TransactionCase):
+    ...
+```
+
+Run only on CI with `--test-tags=external`.
+
+### 8. Test Error Paths
+
+```python
+from odoo.exceptions import AccessError, ValidationError
+
+
+def test_access(self):
+    with self.assertRaises(AccessError):
+        self.env['business.trip'].with_user(self.portal_user).search([])
+
+
+def test_validation(self):
+    with self.assertRaises(ValidationError):
+        self.env['business.trip'].create({'name': False})
+```
+
+### 9. Subtests for data-driven checks
+
+```python
+def test_cases(self):
+    for raw, expected in [('42', 42), (' 42 ', 42), ('0', 0)]:
+        with self.subTest(raw=raw):
+            self.assertEqual(self.env['my.model']._parse_int(raw), expected)
+```
+
+### 10. Minimal Template
+
+```python
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestBusinessTrip(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env['res.partner'].create({'name': 'Alice'})
+        cls.trip = cls.env['business.trip'].create({
+            'name': 'Demo', 'partner_id': cls.partner.id,
+        })
+
+    def test_01_confirm(self):
+        self.trip.action_confirm()
+        self.assertEqual(self.trip.state, 'confirmed')
+
+    def test_02_cancel_requires_manager(self):
+        from odoo.exceptions import AccessError
+        with self.assertRaises(AccessError):
+            self.trip.with_user(self.env.ref('base.user_demo')).action_cancel()
+```
+
+---
+
+## Base Code Reference
+
+The guide is based on the Odoo 16 source tree. Reference files:
+
+| File | Contents |
+|------|----------|
+| `odoo/tests/__init__.py` | Re-exports `TransactionCase`, `SingleTransactionCase`, `HttpCase`, `Form`, decorators |
+| `odoo/tests/common.py` | `BaseCase`, `TransactionCase`, `SingleTransactionCase`, `HttpCase`, `ChromeBrowser`, decorators `tagged` / `users` / `warmup` / `no_retry` / `standalone`, helpers `new_test_user`, `RecordCapturer`, `mute_logger` |
+| `odoo/tests/form.py` | `Form`, `O2MProxy`, `M2MProxy` |
+| `odoo/tests/case.py` | Low-level `TestCase` |
+| `odoo/tests/loader.py` | Test discovery |
+| `odoo/tests/tag_selector.py` | `--test-tags` parser |
+
+**For more Odoo 16 guides, see [SKILL.md](../SKILL.md)**

--- a/skills/odoo-16.0/references/odoo-16-transaction-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-transaction-guide.md
@@ -1,0 +1,793 @@
+---
+name: odoo-16-transaction
+description: Complete guide for handling database transactions, UniqueViolation errors, savepoints, and commit operations in Odoo 16.
+globs: "**/*.{py,xml}"
+topics:
+  - Transaction states and isolation
+  - UniqueViolation and other psycopg2 error codes
+  - Savepoint usage patterns (flushing vs non-flushing)
+  - commit() and rollback() best practices
+  - InFailedSqlTransaction recovery
+  - Serialization errors and FOR UPDATE NOWAIT
+  - flush_all / invalidate_all
+  - Cross-cursor patterns
+when_to_use:
+  - Handling duplicate key errors
+  - Working with savepoints for error isolation
+  - Understanding transaction abort states
+  - Preventing serialization conflicts
+  - Writing resilient cron / batch code
+---
+
+# Odoo 16 Transaction Guide
+
+Complete guide for handling database transactions, psycopg2 errors, savepoints, and commits in Odoo 16.
+
+## Table of Contents
+
+1. [Transaction States](#transaction-states)
+2. [UniqueViolation Errors](#uniqueviolation-errors)
+3. [Savepoint Usage](#savepoint-usage)
+4. [commit() and rollback()](#commit-and-rollback)
+5. [Transaction Aborted Errors](#transaction-aborted-errors)
+6. [Serialization Errors](#serialization-errors)
+7. [Flush & Cache Interaction](#flush--cache-interaction)
+8. [Test Mode & Cross-Cursor Patterns](#test-mode--cross-cursor-patterns)
+9. [Exception Classes](#exception-classes)
+
+---
+
+## Transaction States
+
+### PostgreSQL Transaction Isolation
+
+Odoo 16 uses **REPEATABLE READ** as the default isolation level (set once on the psycopg2 connection in `odoo/sql_db.py`):
+
+```python
+# odoo/sql_db.py
+from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
+
+class Cursor(BaseCursor):
+    def __init__(self, pool, dbname, dsn):
+        ...
+        self.connection.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
+```
+
+What this means in practice:
+
+- Your transaction sees a snapshot taken at its first query
+- Concurrent updates on the same rows by another transaction cause a **serialization error** (SQLSTATE `40001`) when you try to write them
+- Schema changes by other transactions are not visible mid-transaction
+
+### Transaction State Flow
+
+```
+Normal --[error]--> ABORTED --[rollback]--> Normal
+                       |
+                       +--[any SQL]--> InFailedSqlTransaction (25P02)
+                       +--[commit]---> ERROR (cannot commit aborted tx)
+```
+
+Once PostgreSQL aborts the transaction, **every subsequent statement fails** until you `ROLLBACK` or `ROLLBACK TO SAVEPOINT`.
+
+---
+
+## UniqueViolation Errors
+
+### What triggers it
+
+PostgreSQL error code `23505` - raised when an INSERT/UPDATE would violate a `UNIQUE` constraint.
+
+```python
+import psycopg2
+
+self.create({'email': 'user@example.com'})
+self.create({'email': 'user@example.com'})  # -> psycopg2.errors.UniqueViolation
+```
+
+### Odoo's built-in conversion
+
+Odoo converts Postgres constraint errors into friendlier messages via `PGERROR_TO_OE` (`odoo/models.py`):
+
+```python
+# odoo/models.py
+PGERROR_TO_OE = defaultdict(
+    lambda: (lambda model, fvg, info, pgerror: {'message': tools.ustr(pgerror)}),
+    {
+        '23502': convert_pgerror_not_null,    # NOT NULL
+        '23505': convert_pgerror_unique,      # UNIQUE
+        '23514': convert_pgerror_constraint,  # CHECK
+    },
+)
+```
+
+`convert_pgerror_unique` opens a **fresh cursor** to introspect `pg_constraint`, because the original transaction is already aborted:
+
+```python
+# odoo/models.py
+def convert_pgerror_unique(model, fields, info, e):
+    # new cursor since we're probably in an error handler in a blown transaction
+    with closing(model.env.registry.cursor()) as cr_tmp:
+        cr_tmp.execute("""
+            SELECT conname, t.relname, ARRAY(
+                SELECT attname FROM pg_attribute
+                 WHERE attrelid = conrelid AND attnum = ANY(conkey)
+            ) as columns
+              FROM pg_constraint
+              JOIN pg_class t ON t.oid = conrelid
+             WHERE conname = %s
+        """, (e.diag.constraint_name,))
+```
+
+### Handling UniqueViolation correctly
+
+```python
+import psycopg2
+
+# BAD: no savepoint -> transaction is blown after catch
+try:
+    self.create({'email': email})
+except psycopg2.errors.UniqueViolation:
+    existing = self.search([('email', '=', email)])  # InFailedSqlTransaction!
+
+# GOOD: isolate with a savepoint and catch outside it
+try:
+    with self.env.cr.savepoint():
+        self.create({'email': email})
+except psycopg2.errors.UniqueViolation:
+    pass
+# Transaction remains valid; you can continue.
+
+# PREFERRED for unique keys: let the database arbitrate, isolate the race,
+# then retry or re-read from a fresh transaction if needed.
+try:
+    with self.env.cr.savepoint():
+        self.create({'email': email})
+except psycopg2.errors.UniqueViolation:
+    raise  # let the caller retry, or reopen a fresh transaction before re-reading
+
+# A pre-check can still be a fast path, but it is not race-safe on its own.
+existing = self.search([('email', '=', email)], limit=1)
+if not existing:
+    self.create({'email': email})
+```
+
+---
+
+## Savepoint Usage
+
+### What a savepoint is
+
+A savepoint is a nested transaction you can roll back independently of the outer transaction. In Odoo 16, `cr.savepoint()` is the supported API: it issues the underlying `SAVEPOINT`, `ROLLBACK TO SAVEPOINT`, and `RELEASE SAVEPOINT` statements for you, and the default `flush=True` mode also coordinates ORM flush/cache handling.
+
+```python
+# Preferred in business code: let Odoo manage the savepoint lifecycle
+with self.env.cr.savepoint():
+    self.create({'name': 'something'})
+    ...
+```
+
+Manual `SAVEPOINT` SQL is only a low-level raw-SQL fallback. It is **not** a drop-in substitute for `cr.savepoint()` when ORM-managed state, flush behavior, or cache invalidation are involved.
+
+If you ever have to manage a savepoint manually in a tightly scoped low-level path, keep it conservative:
+
+- Use a short, hard-coded name local to that code path only
+- Never derive the savepoint name from user input or other runtime data
+- Treat manual naming as fragile and avoid generalizing this pattern into normal business code
+- Use DB-API parameters only for values inside the statements you run under the savepoint; parameters do not substitute SQL identifiers
+
+```python
+cr.execute('SAVEPOINT import_step')
+try:
+    cr.execute(
+        'UPDATE my_table SET processed = %s WHERE id = %s',
+        (True, record_id),
+    )
+except Exception:
+    cr.execute('ROLLBACK TO SAVEPOINT import_step')
+    cr.execute('RELEASE SAVEPOINT import_step')
+    raise
+else:
+    cr.execute('RELEASE SAVEPOINT import_step')
+```
+
+### Basic pattern
+
+```python
+with self.env.cr.savepoint():
+    self.create({'name': 'something'})
+    raise ValueError("boom")
+# Savepoint rolled back on exception; outer transaction still valid.
+```
+
+### Flushing vs non-flushing
+
+**`flush=True` (default)** - what you want 99% of the time:
+
+- Flushes pending ORM cache writes to the DB before `SAVEPOINT`
+- On success, flushes again before `RELEASE`
+- On rollback, clears the ORM cache (avoids stale data)
+
+**`flush=False`** - only when you deliberately do not want cache interaction:
+
+- You are about to run pure SQL that does not touch ORM-managed fields
+- You want to try `SELECT ... FOR UPDATE NOWAIT` without flushing pending writes
+- DDL/schema operations (see `odoo/tools/sql.py`)
+
+```python
+# FOR UPDATE NOWAIT wants the lock attempt to fail fast,
+# not to flush unrelated cached writes beforehand
+with self.env.cr.savepoint(flush=False):
+    self.env.cr.execute(
+        'SELECT id FROM sale_order WHERE id IN %s FOR UPDATE NOWAIT',
+        (tuple(ids),),
+    )
+```
+
+### Batch import with per-record isolation
+
+```python
+for data in rows:
+    try:
+        with self.env.cr.savepoint():
+            rec = self.create(data)
+            rec._process()
+    except (psycopg2.Error, ValidationError) as e:
+        _logger.warning("Skipping row %s: %s", data.get('ref'), e)
+```
+
+Each failing row rolls back only its own savepoint; the rest still get committed when the request ends.
+
+### `@contextmanager` wrapper
+
+If you need a reusable "try this, undo on any error" helper:
+
+```python
+from contextlib import contextmanager
+
+@contextmanager
+def safe_step(env, label):
+    with env.cr.savepoint():
+        try:
+            yield
+        except Exception as e:
+            _logger.exception("Step %s failed", label)
+            raise
+
+with safe_step(self.env, 'confirm'):
+    order.action_confirm()
+```
+
+### Anti-patterns
+
+```python
+# BAD: manual SAVEPOINT with reused name
+cr.execute('SAVEPOINT foo')
+cr.execute('RELEASE SAVEPOINT foo')
+cr.execute('SAVEPOINT foo')  # fine but fragile; forget to release -> leak
+
+# GOOD: context manager auto-names with uuid
+with self.env.cr.savepoint():
+    ...
+
+# BAD: swallowing the error and then doing unrelated ORM work
+try:
+    self.create(vals)
+except Exception:
+    pass
+self.search([])  # works, but only if no DB error happened;
+                 # with psycopg2 errors this is a guaranteed InFailedSqlTransaction
+```
+
+---
+
+## commit() and rollback()
+
+### `Cursor.commit()` / `Cursor.rollback()`
+
+```python
+# odoo/sql_db.py
+def commit(self):
+    self.flush()
+    result = self._cnx.commit()
+    self.clear()
+    self._now = None
+    self.prerollback.clear()
+    self.postrollback.clear()
+    self.postcommit.run()
+    return result
+
+def rollback(self):
+    self.clear()
+    self.postcommit.clear()
+    self.prerollback.run()
+    result = self._cnx.rollback()
+    self._now = None
+    self.postrollback.run()
+    return result
+```
+
+Note the hooks: `precommit`, `postcommit`, `prerollback`, `postrollback` are callback queues on `BaseCursor`. Business code rarely manipulates them directly.
+
+### When to use `commit()`
+
+**Almost never** in request-handling code. Odoo commits for you at the end of an HTTP request or cron job.
+
+Manual `commit()` is appropriate only in:
+
+1. **Long cron jobs** that must release row locks periodically
+2. **Data imports / migration scripts** that should persist progress
+3. **Init hooks** running outside a normal HTTP/RPC cycle
+
+```python
+# GOOD: cron job committing every chunk
+def _cron_sync(self):
+    for chunk in self._chunks():
+        self._sync_chunk(chunk)
+        self.env.cr.commit()
+```
+
+### When NOT to use `commit()`
+
+```python
+# BAD: mid-business-logic commit makes errors impossible to roll back
+def create_order(self, vals):
+    order = self.create(vals)
+    self.env.cr.commit()           # point of no return
+    order.action_confirm()         # if this fails, order is orphaned
+    self.env.cr.commit()
+```
+
+### `rollback()` in error handlers
+
+```python
+def batch_import(self, rows):
+    try:
+        for row in rows:
+            self.create(row)
+        self.env.cr.commit()
+    except Exception:
+        self.env.cr.rollback()
+        _logger.exception("Batch import failed, rolled back")
+        raise
+```
+
+### Cursor as context manager
+
+```python
+# odoo/sql_db.py - BaseCursor.__enter__/__exit__ auto-commits on success
+with self.env.registry.cursor() as cr:
+    cr.execute("UPDATE ...")
+# auto-commit on clean exit, auto-close always
+```
+
+---
+
+## Transaction Aborted Errors
+
+### Symptom
+
+```
+psycopg2.errors.InFailedSqlTransaction:
+current transaction is aborted, commands ignored until end of transaction block
+```
+
+### Cause
+
+```
+1. Transaction starts
+2. A query fails (UniqueViolation, NotNullViolation, etc.)
+3. PostgreSQL flags the transaction as aborted
+4. Every subsequent SQL fails with 25P02 until you ROLLBACK
+```
+
+### Recovery
+
+Either:
+
+- Rollback the whole transaction: `self.env.cr.rollback()` (loses all uncommitted work)
+- Or isolate the error beforehand with `savepoint()` so only the savepoint is rolled back
+
+```python
+# GOOD: savepoint keeps outer transaction alive
+try:
+    with self.env.cr.savepoint():
+        self.create({'email': 'dup@x.com'})
+except psycopg2.errors.UniqueViolation:
+    pass
+# We can keep working here.
+self.create({'email': 'ok@x.com'})
+```
+
+### Nested savepoints
+
+Nested savepoints compose correctly: rolling back the inner one keeps the outer savepoint (and outer transaction) valid.
+
+```python
+with self.env.cr.savepoint():           # outer (A)
+    try:
+        with self.env.cr.savepoint():   # inner (B)
+            raise psycopg2.errors.UniqueViolation
+    except psycopg2.errors.UniqueViolation:
+        pass
+    # B rolled back; A and the main tx are still valid
+# A also committed normally here.
+```
+
+---
+
+## Serialization Errors
+
+### What it is
+
+PostgreSQL error code `40001` - under REPEATABLE READ, two transactions that have each read and are now trying to update the same rows can be told "you lose, retry".
+
+```
+ERROR: could not serialize access due to concurrent update
+```
+
+### Typical causes
+
+- Two cron workers running the same job for the same record
+- Two HTTP requests writing the same record in parallel
+- Any code that reads then updates without row-level locking
+
+### The Odoo pattern: `SELECT ... FOR UPDATE NOWAIT`
+
+Used in base modules (`ir_sequence`, `account_edi_document`, `website_sale` payment flow, etc.). Lock the row immediately; if someone else holds it, skip.
+
+```python
+from psycopg2.errors import LockNotAvailable
+
+def _process_safe(self, record):
+    try:
+        with self.env.cr.savepoint(flush=False):
+            self.env.cr.execute(
+                'SELECT id FROM %s WHERE id = %%s FOR UPDATE NOWAIT' % self._table,
+                (record.id,),
+            )
+    except LockNotAvailable:
+        _logger.info("Record %s locked, skipping", record.id)
+        return False
+
+    record._do_process()
+    return True
+```
+
+Key points:
+
+- `FOR UPDATE NOWAIT` raises `LockNotAvailable` (SQLSTATE `55P03`) instead of blocking
+- `savepoint(flush=False)` - we deliberately do not flush pending ORM writes just to try the lock
+- Catch `LockNotAvailable` to gracefully skip
+
+### Batch processing with locking
+
+```python
+from psycopg2.errors import LockNotAvailable
+
+def _batch_process(self, records):
+    processed, skipped = 0, 0
+    for record in records:
+        try:
+            with self.env.cr.savepoint(flush=False):
+                self.env.cr.execute(
+                    'SELECT id FROM %s WHERE id IN %%s FOR UPDATE NOWAIT' % self._table,
+                    (tuple(record.ids),),
+                )
+        except LockNotAvailable:
+            skipped += 1
+            continue
+        record._do_process()
+        processed += 1
+    return processed, skipped
+```
+
+### Retry on serialization error
+
+When you *cannot* avoid the conflict, retry:
+
+```python
+import psycopg2
+import time
+
+def _write_with_retry(self, values, retries=3):
+    for attempt in range(retries):
+        try:
+            return self.write(values)
+        except psycopg2.errors.SerializationFailure:
+            if attempt == retries - 1:
+                raise
+            self.env.cr.rollback()
+            time.sleep(0.05 * (2 ** attempt))   # small backoff
+```
+
+Note: the RPC layer in `odoo/service/model.py` already retries "concurrent update" errors for you at the request level (`MAX_TRIES_ON_CONCURRENCY_FAILURE`), so manual retry loops are only needed inside cron jobs or long-lived sessions.
+
+### Group identical updates
+
+Each individual `UPDATE` is a serialization point. Collapse identical writes:
+
+```python
+from collections import defaultdict
+
+groups = defaultdict(list)
+for rec, amount in zip(records, amounts):
+    groups[amount].append(rec.id)
+
+for amount, ids in groups.items():
+    self.env['fb.daily.expense'].browse(ids).write({'amount': amount})
+```
+
+---
+
+## Flush & Cache Interaction
+
+### `env.flush_all()`
+
+Flushes every pending recompute and write across all models in the current environment.
+
+```python
+# odoo/api.py
+def flush_all(self):
+    self._recompute_all()
+    for model_name in OrderedSet(f.model_name for f in self.cache.get_dirty_fields()):
+        self[model_name].flush_model()
+```
+
+Call it before:
+
+- `cr.execute()` that reads columns you just wrote to
+- An external script that bypasses Odoo's ORM
+- A Postgres trigger-dependent operation
+
+### `env.invalidate_all(flush=True)`
+
+Flushes (by default) and then drops the cache. Use when you suspect the cache is out of sync with the DB (e.g. after raw SQL that modified tracked columns).
+
+```python
+self.env.cr.execute("UPDATE sale_order SET state='done' WHERE id = %s", (oid,))
+# Cache still says state='draft' for that record
+self.env.invalidate_all()
+```
+
+### Savepoints and the cache
+
+`_FlushingSavepoint` (the default) already handles this for you: it flushes before `SAVEPOINT` and clears the cache on `ROLLBACK TO SAVEPOINT`. That is why you rarely need to touch `invalidate_all()` manually when you use savepoints.
+
+---
+
+## Test Mode & Cross-Cursor Patterns
+
+### `registry.in_test_mode()`
+
+Odoo test runs keep a single outer transaction that is rolled back at the end of the test. Code that opens a new cursor behaves differently in tests.
+
+```python
+# odoo/modules/registry.py
+def in_test_mode(self):
+    return self.test_cr is not None
+```
+
+If you need a "real" independent cursor in production but a shared test cursor during tests, use `self.env.registry.cursor()`. In test mode this returns a `TestCursor` wrapping the main cursor so rollbacks still work. That means the "survives caller rollback" framing is production-oriented; tests may intentionally behave differently.
+
+```python
+from contextlib import closing
+
+def _log_audit(self, message):
+    # Fresh cursor for production-style independent audit logging;
+    # tests may still route this through the shared test cursor wrapper.
+    with closing(self.env.registry.cursor()) as cr:
+        env = odoo.api.Environment(cr, self.env.uid, self.env.context)
+        env['audit.log'].create({'message': message})
+        cr.commit()
+```
+
+### Why a new cursor?
+
+Two use cases:
+
+1. **Auditing / logging** that, in production, should outlive a rollback in the caller
+2. **Error handlers** that need to run SQL when the outer transaction is already aborted (this is why `convert_pgerror_unique` opens a new cursor)
+
+Warning: a new cursor opens a new PostgreSQL transaction. It cannot see uncommitted data from the outer cursor. Only use it when you genuinely want isolation.
+
+---
+
+## Exception Classes
+
+All Odoo exception types live in `odoo/exceptions.py`:
+
+| Class | Inherits | Typical meaning |
+|-------|----------|-----------------|
+| `UserError` | `Exception` | Generic user-facing error (shown as dialog). Use for business-rule violations. |
+| `ValidationError` | `UserError` | Python constraint violation (`@api.constrains` or field check). |
+| `AccessError` | `UserError` | Access right / record rule denial. |
+| `AccessDenied` | `UserError` | Login or password error - no traceback attached. |
+| `MissingError` | `UserError` | Record does not exist or was deleted. |
+| `RedirectWarning` | `Exception` | Error with a follow-up action / button for the user. |
+| `CacheMiss` | `KeyError` | Internal: value not in ORM cache. Do not raise from business code. |
+
+```python
+from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
+
+if not partner.email:
+    raise UserError(_("Partner has no email"))
+
+if amount < 0:
+    raise ValidationError(_("Amount must be positive"))
+```
+
+### psycopg2 error classes
+
+The database-level errors you will catch most often:
+
+```python
+import psycopg2
+from psycopg2 import errors
+from psycopg2.errors import (
+    UniqueViolation,        # 23505
+    NotNullViolation,       # 23502
+    CheckViolation,         # 23514
+    SerializationFailure,   # 40001
+    LockNotAvailable,       # 55P03
+    InFailedSqlTransaction, # 25P02
+)
+```
+
+Always isolate these with `with cr.savepoint():`, then catch them outside the block unless you are about to rollback the full transaction.
+
+---
+
+## Quick Reference
+
+### PostgreSQL Error Codes
+
+| Code | Name | Odoo handler / typical fix |
+|------|------|-----------------------------|
+| 23502 | NOT NULL violation | `convert_pgerror_not_null` |
+| 23505 | UNIQUE violation | `convert_pgerror_unique` |
+| 23514 | CHECK violation | `convert_pgerror_constraint` |
+| 40001 | Serialization failure | Retry, or use `FOR UPDATE NOWAIT` |
+| 25P02 | In-failed SQL transaction | `ROLLBACK` or use savepoints |
+| 55P03 | Lock not available | Skip / retry later |
+
+### Savepoint decision tree
+
+```
+Need error isolation?
+|- Single op that might fail                -> with cr.savepoint(): ...
+|- Batch of N ops with individual failures   -> for x in xs: with cr.savepoint(): ...
+|- Trying to grab a lock                     -> with cr.savepoint(flush=False): SELECT ... FOR UPDATE NOWAIT
+|- Schema / DDL                              -> with cr.savepoint(flush=False): ...
+```
+
+### Transaction recovery checklist
+
+After catching a database error, ask:
+
+- [ ] Was it caught inside a `with cr.savepoint():`? If yes, transaction is still valid.
+- [ ] If not, do I need to `env.cr.rollback()` the whole transaction?
+- [ ] Do I need to `env.invalidate_all()` to drop stale cache entries?
+- [ ] Will the caller (HTTP/cron) retry, or should I retry here?
+
+### Best Practices
+
+1. Use `with cr.savepoint()` for anything that may fail.
+2. Never `commit()` mid-business-logic.
+3. For unique keys, prefer savepoint-scoped create flows that let the database arbitrate races, then retry or re-read from a fresh transaction if needed.
+4. Use `SELECT ... FOR UPDATE NOWAIT` + `savepoint(flush=False)` for cron contention.
+5. Group identical updates to minimize serialization conflicts.
+6. Flush before raw SQL reads.
+7. Use a new cursor (`registry.cursor()`) only for audit / error-path logging.
+
+---
+
+## Common Patterns Reference
+
+### Pattern 1: Safe batch create
+
+```python
+import psycopg2
+from odoo.exceptions import ValidationError
+
+def batch_create_safe(self, rows):
+    created, failed = [], []
+    for data in rows:
+        try:
+            with self.env.cr.savepoint():
+                created.append(self.create(data))
+        except (psycopg2.Error, ValidationError) as e:
+            failed.append({'data': data, 'error': str(e)})
+    return created, failed
+```
+
+### Pattern 2: Unique-key create with a retry boundary
+
+```python
+import psycopg2
+
+def create_by_key(self, values):
+    try:
+        with self.env.cr.savepoint():
+            return self.create(values)
+    except psycopg2.errors.UniqueViolation:
+        # Another transaction won the race; retry or re-read in a fresh transaction.
+        raise
+```
+
+### Pattern 3: Record locking (Odoo standard)
+
+```python
+from psycopg2.errors import LockNotAvailable
+
+def process_with_lock(self, records):
+    for record in records:
+        try:
+            with self.env.cr.savepoint(flush=False):
+                self.env.cr.execute(
+                    'SELECT id FROM %s WHERE id IN %%s FOR UPDATE NOWAIT' % self._table,
+                    (tuple(record.ids),),
+                )
+        except LockNotAvailable:
+            _logger.info("Record %s locked, skipping", record.id)
+            continue
+        record._do_process()
+```
+
+### Pattern 4: Retry on serialization error
+
+```python
+import psycopg2
+import time
+
+def write_with_retry(self, vals, retries=3):
+    for attempt in range(retries):
+        try:
+            return self.write(vals)
+        except psycopg2.errors.SerializationFailure:
+            if attempt == retries - 1:
+                raise
+            self.env.cr.rollback()
+            time.sleep(0.05 * (2 ** attempt))
+```
+
+### Pattern 5: Production-style audit log with a separate cursor
+
+```python
+from contextlib import closing
+import odoo
+
+def _audit(self, message):
+    with closing(self.env.registry.cursor()) as cr:
+        env = odoo.api.Environment(cr, self.env.uid, self.env.context)
+        env['audit.log'].create({'message': message})
+        cr.commit()
+```
+
+### Pattern 6: Flush before raw SQL
+
+```python
+def get_totals(self):
+    self.env['sale.order'].flush_model(['state', 'amount_total'])
+    self.env.cr.execute("""
+        SELECT state, SUM(amount_total)
+          FROM sale_order
+         WHERE state IN %s
+         GROUP BY state
+    """, (('done', 'cancel'),))
+    return dict(self.env.cr.fetchall())
+```
+
+---
+
+## Base Code Reference
+
+- `odoo/sql_db.py` - `Cursor`, `BaseCursor`, `Savepoint`, `_FlushingSavepoint`, isolation level
+- `odoo/api.py` - `Environment.flush_all`, `Environment.invalidate_all`, precommit/postcommit hooks
+- `odoo/exceptions.py` - `UserError`, `ValidationError`, `AccessError`, `AccessDenied`, `MissingError`, `RedirectWarning`, `CacheMiss`
+- `odoo/models.py` - `PGERROR_TO_OE`, `convert_pgerror_unique`, `convert_pgerror_not_null`, `convert_pgerror_constraint`
+- `odoo/service/model.py` - RPC-level concurrency retry loop (`MAX_TRIES_ON_CONCURRENCY_FAILURE`)
+- `odoo/modules/registry.py` - `Registry.cursor()`, `in_test_mode()`
+- `odoo/addons/base/models/ir_sequence.py` - reference `FOR UPDATE NOWAIT` usage
+- `odoo/addons/account_edi/models/account_edi_document.py` - reference locking pattern
+- PostgreSQL docs: Transaction Isolation, Error Codes

--- a/skills/odoo-16.0/references/odoo-16-translation-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-translation-guide.md
@@ -1,0 +1,900 @@
+---
+name: odoo-16-translation
+description: Complete guide for Odoo 16 translations and localization. Covers Python translations with _() and _lt(), JavaScript/OWL translations with _t(), QWeb template translations, field translations with translate=True (JSONB column), PO/POT file structure, translation export/import, language management.
+globs: "**/*.{py,js,xml}"
+topics:
+  - Python translations (_ and _lt)
+  - JavaScript translations (_t)
+  - QWeb template translations
+  - Field translations (translate=True, JSONB storage)
+  - PO / POT file structure
+  - Translation export/import
+  - Language / context switching
+when_to_use:
+  - Adding translatable strings to Python code
+  - Adding translations to JavaScript/OWL components
+  - Creating translatable QWeb templates
+  - Setting up translated fields
+  - Exporting/importing translations
+  - Reading translations in a specific language
+---
+
+# Odoo 16 Translation & Localization Guide
+
+Complete guide for translating and localizing Odoo 16 modules.
+
+> **Odoo 16 storage model**: since Odoo 16, the legacy `ir.translation` table is **gone for model field translations**. A field declared with `translate=True` is stored as a **JSONB column** `{lang_code: value}` on the model's own table. The old `ir.translation` model has been removed in v16 - you will not find it via `self.env['ir.translation']`. "Code" translations (`_()`, `_t()`) are still loaded from PO files into memory at runtime, not stored in the database.
+
+## Quick Reference
+
+| Context | Function | Example |
+|---------|----------|---------|
+| Python code (inside method) | `_()` | `_("Hello World")` |
+| Python module-level constants | `_lt()` | `TITLE = _lt("Module Title")` |
+| JavaScript / OWL | `_t()` | `_t("Hello World")` |
+| JavaScript lazy (alias of `_t` in v16) | `_lt()` | `const L = _lt("Later")` |
+| Field definition | `translate=True` | `name = fields.Char(translate=True)` |
+| HTML field term translation | `translate=html_translate` | `body = fields.Html(translate=html_translate)` |
+
+---
+
+## Table of Contents
+
+1. [Python Translations](#python-translations)
+2. [Field Translations](#field-translations)
+3. [QWeb Template Translations](#qweb-template-translations)
+4. [JavaScript / OWL Translations](#javascript--owl-translations)
+5. [Module Translation Structure](#module-translation-structure)
+6. [Translation Export / Import](#translation-export--import)
+7. [Language Management](#language-management)
+8. [Translation Types](#translation-types)
+9. [Best Practices](#best-practices)
+10. [Anti-Patterns](#anti-patterns)
+11. [Testing Translations](#testing-translations)
+
+---
+
+## Python Translations
+
+### Standard translation function `_()`
+
+`_` is a `GettextAlias` instance defined in `odoo/tools/translate.py`; it reads the current `env.context['lang']` from the calling frame and looks up the translated string in the code translations loaded in memory.
+
+```python
+from odoo import _                        # re-export of odoo.tools.translate._
+# or:
+from odoo.tools.translate import _
+
+# Simple translation
+message = _("Hello World")
+
+# Positional formatting
+message = _("Hello %s", user.name)
+
+# Named formatting
+message = _(
+    "Hello %(name)s, you have %(count)d messages",
+    name=user.name, count=5,
+)
+```
+
+Important: the source string passed to `_()` must be a **string literal**. Do not build it with f-strings or `+` or `format()` - the extractor cannot recognize dynamic strings.
+
+```python
+# BAD - not extractable
+_(f"Hello {user.name}")
+
+# GOOD - translator-friendly
+_("Hello %(name)s", name=user.name)
+```
+
+### Lazy translation `_lt()` for module-level constants
+
+When a translatable string is evaluated at import time (class attribute, module constant, Selection label default, etc.), the user's language context is not known yet. Use `_lt()` to defer the lookup until the string is actually rendered.
+
+```python
+from odoo.tools.translate import _lt
+
+# Module-level
+MODULE_NAME = _lt("My Module")
+STATUS_DRAFT = _lt("Draft")
+STATUS_DONE = _lt("Done")
+
+class MyModel(models.Model):
+    _name = 'my.model'
+    _description = 'My Model'
+
+    label = fields.Char(default=lambda self: str(MODULE_NAME))
+
+    def get_status_label(self, status):
+        return {'draft': STATUS_DRAFT, 'done': STATUS_DONE}[status]
+```
+
+In Odoo 16, `_lt` is a **class** (`class _lt:` in `odoo/tools/translate.py`). Each `_lt("...")` instance defers `_get_translation` until `__str__` / `__add__` etc. are called.
+
+> There is **no `LazyTranslate(__name__)` pattern** in v16 — that shape appears in Odoo 18. In v16 you simply import `_lt` and instantiate it with the source string; the resulting object is a lazy `_lt` instance that resolves on `__str__`/`__add__`/etc.
+
+### Where `_()` resolves language from
+
+`GettextAlias._get_lang()` walks the call stack looking for a context:
+
+1. If the calling frame has `self` with an `env`, use `self.env.lang`
+2. If it has an `env` local, use `env.lang`
+3. Otherwise fall back to `lang='en_US'` (no translation)
+
+This means `_()` "just works" inside any model method, controller, or wizard that has `self`. For code run outside a model method (e.g. helper functions), wrap with `with_context(lang=...)` or use `_lt` + resolve later.
+
+---
+
+## Field Translations
+
+### Declaring a translatable field
+
+```python
+from odoo import fields, models
+from odoo.tools.translate import html_translate
+
+class Product(models.Model):
+    _name = 'my.product'
+    _description = 'Product'
+
+    # Whole-value translation: entire string replaced per language
+    name = fields.Char(string='Name', translate=True)
+
+    # Same for Text
+    summary = fields.Text(translate=True)
+
+    # HTML with term-by-term translation (translates pieces of the markup)
+    description = fields.Html(translate=html_translate)
+```
+
+### Storage: JSONB per field (Odoo 16+, still used in v16)
+
+Under the hood, `translate=True` changes the Postgres column type to `jsonb`. The JSON payload is `{lang_code: value}`:
+
+```json
+{
+    "en_US": "Product",
+    "fr_FR": "Produit",
+    "vi_VN": "San pham"
+}
+```
+
+Odoo 16 field code (`odoo/fields.py`, `_String` family):
+
+```python
+@property
+def column_type(self):
+    return ('jsonb', 'jsonb') if self.translate else ('varchar', pg_varchar(self.size))
+```
+
+Reading a translatable field picks the value for the current `env.context['lang']`, falling back to `en_US` if that language's key is missing. Writing to a translatable field updates the JSON key for the current language.
+
+### Reading in a specific language
+
+```python
+# Read in French
+name_fr = partner.with_context(lang='fr_FR').name
+
+# Read in Vietnamese
+name_vi = partner.with_context(lang='vi_VN').name
+
+# Read every stored translation as a raw dict - use get_field_translations
+translations, ctx = partner.get_field_translations('name')
+# translations: [{'lang': 'fr_FR', 'source': 'Name', 'value': 'Nom'}, ...]
+```
+
+### Writing translations programmatically
+
+```python
+# Set the value for the current language only
+partner.with_context(lang='fr_FR').name = 'Nom'
+
+# Set multiple languages at once using update_field_translations
+partner.update_field_translations('name', {
+    'fr_FR': 'Nom',
+    'es_ES': 'Nombre',
+    'vi_VN': 'Ten',
+})
+
+# To void a translation for a lang (fallback to en_US), pass False
+partner.update_field_translations('name', {'fr_FR': False})
+```
+
+`update_field_translations` and the internal `_update_field_translations` are defined on `BaseModel` in `odoo/models.py` (v16).
+
+### Field `string` and `help` - automatic
+
+The `string` label and `help` tooltip on every field are already marked translatable by Odoo's extractor. You do **not** need to wrap them in `_()`:
+
+```python
+state = fields.Selection(
+    [('draft', 'Draft'), ('done', 'Done')],
+    string='Status',
+    help='Document state',
+)
+```
+
+Both `'Status'`, `'Document state'`, `'Draft'`, `'Done'` end up in the `.pot` file automatically.
+
+### Term-by-term translation via `html_translate`
+
+When translating HTML, whole-value translation is usually wrong - you want translators to see each paragraph as a term. Use `translate=html_translate`:
+
+```python
+from odoo.tools.translate import html_translate
+
+description = fields.Html(translate=html_translate)
+```
+
+Stored as JSONB too, but internally broken into terms during extraction and recomposed on read.
+
+---
+
+## QWeb Template Translations
+
+### Text content is auto-translatable
+
+Any text inside a translatable element in a QWeb template is extracted:
+
+```xml
+<template id="thanks_page" xml:space="preserve">
+    <div>
+        <h2>Thank you for your order</h2>
+        <p>We will process it within 24 hours.</p>
+    </div>
+</template>
+```
+
+Both the heading and paragraph land in the `.pot`.
+
+### Translatable attributes
+
+The extractor considers these attributes translatable: `string`, `placeholder`, `title`, `alt`, `help`, `confirm`, `aria-label`, `data-tooltip`, ...
+
+```xml
+<field name="email" string="Email" placeholder="name@example.com"/>
+<button string="Save" confirm="Save changes?"/>
+<span title="Information" aria-label="Info"/>
+```
+
+### Disabling translation
+
+```xml
+<span t-translation="off">v16.0</span>
+<code t-translation="off">user_id</code>
+```
+
+### Dynamic content
+
+Keep the full sentence as one translatable string, not concatenated pieces:
+
+```xml
+<!-- BAD: grammatically untranslatable in many languages -->
+<div>
+    Hello <t t-esc="user.name"/>, you have
+    <t t-esc="count"/> messages.
+</div>
+
+<!-- GOOD: single translatable sentence with named placeholders -->
+<div>
+    <t t-esc="_t('Hello %(name)s, you have %(count)d messages',
+                 name=user.name, count=count)"/>
+</div>
+```
+
+### Odoo 16 view syntax reminder
+
+In Odoo 16 views:
+- List views still use `<tree>` (not `<list>` — `<list>` arrived in v18)
+- Client-side dynamic modifiers use `attrs` / `states`: `attrs="{'invisible': [('state', '=', 'done')]}"`, `attrs="{'readonly': [('locked', '=', True)]}"`, `attrs="{'required': [('type', '=', 'post')]}"`. Direct attributes like `invisible="1"` or `invisible="context.get('default_state')"` are accepted in Odoo 16, but they are static/context-time, not record-reactive client modifiers.
+
+This matters for translators only indirectly: the `string=` attributes inside `<tree>` and on fields/buttons follow the normal extraction rules.
+
+---
+
+## JavaScript / OWL Translations
+
+### Translation function `_t`
+
+`_t` is exported from `@web/core/l10n/translation` (source: `addons/web/static/src/core/l10n/translation.js`):
+
+```javascript
+import { _t } from "@web/core/l10n/translation";
+
+// Simple
+const message = _t("Good morning");
+
+// With sprintf-style placeholders
+const msg = _t("Good morning %s", userName);
+
+// Named placeholders (via sprintf)
+const formatted = _t(
+    "Hello %(name)s, you have %(count)d new messages",
+    { name: user.name, count: count }
+);
+```
+
+### `_lt` - alias of `_t` in Odoo 16
+
+In v16, the JS side does not have a distinct lazy implementation. `_lt` is defined as:
+
+```javascript
+// addons/web/static/src/core/l10n/translation.js
+export const _lt = (term, ...values) => _t(term, ...values);
+```
+
+However, `_t` itself returns a `LazyTranslatedString` when the translation bundle has not finished loading yet. That lazy string resolves when converted to a primitive string (`.toString()` / `.valueOf()` / template literal). So in practice:
+
+- Use `_t(...)` everywhere in v16 JS/OWL
+- Prefer `_lt(...)` for strings defined at module-top-level or as class static fields, to signal intent
+
+```javascript
+// Module-level / class static: use _lt for clarity
+class MyDialog extends Component {
+    static title = _lt("Confirm");
+}
+```
+
+### In OWL components
+
+```javascript
+/** @odoo-module **/
+import { Component, useState } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+
+class MyComponent extends Component {
+    static template = "my_module.MyComponent";
+
+    setup() {
+        this.state = useState({
+            title: _t("My Component"),
+            loading: _t("Loading..."),
+        });
+    }
+
+    onSave() {
+        this.notification.add(_t("Saved successfully"), { type: "success" });
+    }
+}
+```
+
+### Markup in translations
+
+```javascript
+import { markup } from "@odoo/owl";
+
+const msg = _t("I love %s", markup("<b>Odoo</b>"));
+// HTML preserved when injected into a template
+```
+
+### Note about loading
+
+JS translations are shipped to the browser via `/web/webclient/translations/<lang>` (see `addons/web/controllers/webclient.py`). They are loaded once per session before the action manager starts. The `translationIsReady` `Deferred` in `translation.js` resolves when they are available.
+
+---
+
+## Module Translation Structure
+
+### Directory layout
+
+```
+my_module/
+|-- i18n/
+|   |-- my_module.pot      # Template - EXTRACTED source strings (required!)
+|   |-- fr.po              # French translation
+|   |-- de.po              # German translation
+|   |-- vi.po              # Vietnamese translation
+|   `-- i18n_extra/        # Optional locale overrides
+|       `-- fr_BE.po       # Belgian French override of fr.po
+|-- models/
+|   `-- my_model.py        # Python code with _() / _lt()
+|-- views/
+|   `-- my_model_views.xml # XML with string=, placeholder=
+|-- static/
+|   `-- src/
+|       |-- js/
+|       |   `-- my_component.js   # JS with _t()
+|       `-- xml/
+|           `-- my_component.xml  # OWL template
+`-- __manifest__.py
+```
+
+**Rule of thumb for this project**: the `i18n/` folder MUST contain the `.pot` template, not just locale `.po` files. The `.pot` is the source of truth - translators regenerate their `.po` from it.
+
+### `__manifest__.py` example
+
+```python
+{
+    'name': 'My Module',
+    'version': '16.0.1.0.0',
+    'author': 'UncleCat',
+    'license': 'LGPL-3',
+    'depends': ['base'],
+    'data': [
+        'views/my_model_views.xml',
+    ],
+    'installable': True,
+}
+```
+
+### PO file format
+
+`i18n/fr.po`:
+
+```po
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#       * my_module
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-01 10:00+0000\n"
+"PO-Revision-Date: 2026-04-01 10:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: my_module
+#. odoo-python
+#: code:addons/my_module/models/my_model.py:0
+#, python-format
+msgid "Hello %(name)s"
+msgstr "Bonjour %(name)s"
+
+#. module: my_module
+#: model:ir.model.fields,field_description:my_module.field_my_model__name
+msgid "Name"
+msgstr "Nom"
+
+#. module: my_module
+#. odoo-javascript
+#: code:addons/my_module/static/src/js/my_component.js:0
+msgid "Saved successfully"
+msgstr "Enregistre avec succes"
+```
+
+Important comment markers:
+
+- `#. odoo-python` - string from `_()` / `_lt()`
+- `#. odoo-javascript` - string from `_t()`
+- `#: model:ir.model.fields,...` - auto-translatable field label/help
+- `#: model:ir.model,name:model_...` - auto-translatable `_description`
+- `#: model:ir.ui.view,arch_db:...` - QWeb template text
+
+### Language fallback
+
+Odoo walks from the requested locale down to any available variant:
+
+```
+fr_BE -> fr_FR (if no fr_BE.po is loaded) -> en_US (source)
+vi_VN -> vi (if vi.po present) -> en_US
+```
+
+---
+
+## Translation Export / Import
+
+### Generating / updating the `.pot`
+
+This project expects a `.pot` file in `i18n/` at all times. Regenerate it after adding/removing translatable strings:
+
+```bash
+./odoo-bin -c odoo.conf \
+    -d <your_db> \
+    --modules=my_module \
+    --i18n-export=addons/my_module/i18n/my_module.pot \
+    --addons-path=addons,custom_addons
+```
+
+To export a translated `.po`:
+
+```bash
+./odoo-bin -c odoo.conf \
+    -d <your_db> \
+    --modules=my_module \
+    --i18n-export=addons/my_module/i18n/fr.po \
+    -l fr_FR
+```
+
+To import/update a `.po` into the database:
+
+```bash
+./odoo-bin -c odoo.conf \
+    -d <your_db> \
+    --i18n-import=addons/my_module/i18n/fr.po \
+    -l fr_FR \
+    --i18n-overwrite
+```
+
+### UI export / import
+
+- **Settings -> Translations -> Export Terms**: pick language, format (PO/CSV/TGZ), modules
+- **Settings -> Translations -> Import Terms**: upload PO, pick language, tick "Overwrite"
+
+### Programmatic export
+
+```python
+import io
+from odoo.tools.translate import TranslationModuleReader
+
+buf = io.BytesIO()
+reader = TranslationModuleReader(
+    cr=self.env.cr,
+    modules=['my_module'],
+    lang='fr_FR',
+)
+# Iterate and write PO via polib, or call the higher-level exporter
+# used by the export wizard (base/wizard/base_export_language.py).
+```
+
+### Programmatic import
+
+```python
+from odoo.tools.translate import TranslationImporter
+
+importer = TranslationImporter(self.env.cr)
+importer.load_file('/path/to/my_module/i18n/fr.po', lang='fr_FR')
+importer.save(overwrite=True)
+```
+
+### Reloading after adding strings
+
+After you add new `_()` / `_t()` / `translate=True` strings:
+
+1. Regenerate `.pot` (`--i18n-export`)
+2. Merge into existing `.po` files with `msgmerge` (or re-export from DB)
+3. Translate the new `msgid` entries
+4. `--i18n-import --i18n-overwrite` to push back
+5. Or reinstall the module, which calls `_load_module_terms`
+
+```python
+# odoo/addons/base/models/ir_module.py
+self.env['ir.module.module']._load_module_terms(
+    modules=['my_module'],
+    langs=['fr_FR'],
+    overwrite=True,
+)
+```
+
+---
+
+## Language Management
+
+### The `res.lang` model
+
+Defined in `odoo/addons/base/models/res_lang.py`:
+
+```python
+class Lang(models.Model):
+    _name = "res.lang"
+    _description = "Languages"
+
+    name = fields.Char(required=True)
+    code = fields.Char(string='Locale Code', required=True)       # 'fr_FR'
+    iso_code = fields.Char(string='ISO code')                     # 'fr'
+    url_code = fields.Char('URL Code', required=True)             # 'fr'
+    active = fields.Boolean()
+    direction = fields.Selection(
+        [('ltr', 'Left-to-Right'), ('rtl', 'Right-to-Left')],
+        required=True, default='ltr',
+    )
+    date_format = fields.Char(required=True, default='%m/%d/%Y')
+    time_format = fields.Char(required=True, default='%H:%M:%S')
+    week_start = fields.Selection([...], default='7')
+    grouping = fields.Char(required=True, default='[]')
+    decimal_point = fields.Char(required=True, default='.')
+    thousands_sep = fields.Char(default=',')
+```
+
+### Activating / creating a language
+
+```python
+Lang = self.env['res.lang']
+
+# Activate an existing language
+Lang._activate_lang('vi_VN')
+
+# Activate-or-create
+Lang._activate_lang('vi_VN') or Lang._create_lang('vi_VN')
+```
+
+### Installed languages
+
+```python
+# Returns list of (code, name) tuples for all active languages
+installed = self.env['res.lang'].get_installed()
+# [('en_US', 'English (US)'), ('fr_FR', 'French / Francais'), ...]
+
+# Current user language
+current_lang = self.env.lang or 'en_US'
+```
+
+### Switching language per-operation
+
+```python
+# Read translated fields in a specific language
+name_fr = record.with_context(lang='fr_FR').name
+
+# Run a whole piece of logic as if the user were French
+record_fr = record.with_context(lang='fr_FR')
+record_fr.action_confirm()   # any _() inside will use fr_FR
+```
+
+### Date / number / currency localization
+
+Date and number formats come from `res.lang`:
+
+```python
+lang = self.env['res.lang']._lang_get(self.env.lang or 'en_US')
+
+formatted_date = lang.format_date(fields.Date.today())
+formatted_number = lang.format(
+    '%.2f', 1234567.89, grouping=True,
+)  # "1,234,567.89" or "1 234 567,89" depending on lang
+```
+
+Currency formatting goes through `res.currency`:
+
+```python
+formatted = self.currency_id.with_context(lang=self.env.lang).format(amount)
+```
+
+---
+
+## Translation Types
+
+### Type: `code` - Python & JavaScript
+
+- Source: `_()`, `_lt()` in Python; `_t()`, `_lt()` in JS
+- Storage: NOT in the database - loaded from PO files into the per-process code_translations cache at startup / install
+- In the PO: `#. odoo-python` or `#. odoo-javascript` comment
+
+### Type: `model` - `translate=True` whole-value
+
+- Source: `fields.Char(translate=True)`, `fields.Text(translate=True)`
+- Storage: **JSONB column on the model's table** (v16)
+- PO reference: `#: model:ir.model.fields,field_description:module.field_model__fname`
+
+### Type: `model_terms` - callable translate (e.g. `html_translate`)
+
+- Source: `fields.Html(translate=html_translate)`
+- Storage: JSONB, but each translator-visible term is a separate key in an internal dict
+- Terms are extracted from the HTML with `html_translate` and recomposed on read
+
+> There is **no `ir.translation` model in Odoo 16**. Any code you see doing `self.env['ir.translation']...` is from Odoo <= 15 and will fail on v16. Use `get_field_translations` / `update_field_translations` instead.
+
+---
+
+## Best Practices
+
+### DO use named placeholders for dynamic content
+
+```python
+# GOOD
+_("Hello %(name)s, welcome to %(app)s", name=user.name, app='Odoo')
+```
+
+### DON'T concatenate translated strings
+
+```python
+# BAD - unusable in languages with different grammar
+msg = _("Hello") + " " + user.name + ", " + _("welcome")
+```
+
+### DO keep full sentences in one `_()`
+
+```python
+# GOOD
+msg = _("Delete the selected records?")
+
+# BAD - loses context, translators cannot know which verb form to use
+msg = _("Delete") + " " + _("the selected records")
+```
+
+### DO use `_lt()` for module-level constants
+
+```python
+# GOOD
+STATUS_DRAFT = _lt("Draft")
+STATUS_DONE = _lt("Done")
+
+class MyModel(models.Model):
+    @api.depends('state')
+    def _compute_state_label(self):
+        for rec in self:
+            rec.state_label = str({
+                'draft': STATUS_DRAFT,
+                'done': STATUS_DONE,
+            }[rec.state])
+```
+
+### DON'T use `_()` at module scope
+
+```python
+# BAD - translated once at import time using whatever lang was active then
+STATUS_DRAFT = _("Draft")
+```
+
+### DO commit the `.pot` file
+
+The `i18n/<module>.pot` file is the canonical list of translatable strings for the module. Keep it up to date and commit it alongside code changes.
+
+### DO use `with_context(lang=...)` for per-user rendering
+
+```python
+# Send a notification in the partner's own language
+partner = record.partner_id
+body = record.with_context(lang=partner.lang or 'en_US').message_body
+```
+
+---
+
+## Anti-Patterns
+
+### Dynamic source strings
+
+```python
+# BAD - extractor cannot see the string
+message = _(f"User {user.name} created")
+
+# GOOD
+message = _("User %(name)s created", name=user.name)
+```
+
+### Translating technical IDs
+
+```python
+# BAD - XML IDs are not for translation
+xml_id = _("my_module.my_record")
+
+# GOOD
+xml_id = 'my_module.my_record'
+```
+
+### Branching inside translation
+
+```python
+# BAD
+msg = _("Success" if ok else "Failure")
+
+# GOOD
+msg = _("Success") if ok else _("Failure")
+```
+
+### Translation inside hot loops
+
+```python
+# BAD - calls _get_translation per iteration
+for rec in records:
+    label = _("Name")   # same value every time
+    print(f"{label}: {rec.name}")
+
+# GOOD - hoist out of the loop
+label = _("Name")
+for rec in records:
+    print(f"{label}: {rec.name}")
+```
+
+### HTML baked into Python translations
+
+```python
+# BAD - translators have to keep HTML syntax correct
+msg = _("<strong>Error:</strong> Invalid input")
+
+# GOOD - mark up in the template, not in the string
+msg = _("Error: Invalid input")
+```
+
+### Talking to `ir.translation`
+
+```python
+# BAD - will raise KeyError in Odoo 16: model does not exist
+self.env['ir.translation'].search([...])
+
+# GOOD
+translations, ctx = record.get_field_translations('name')
+record.update_field_translations('name', {'fr_FR': 'Nom'})
+```
+
+---
+
+## Testing Translations
+
+### Per-test language switch
+
+```python
+from odoo.tests.common import TransactionCase
+
+class TestTranslation(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['res.lang']._activate_lang('fr_FR')
+
+    def test_translate_field(self):
+        product = self.env['my.product'].create({'name': 'Chair'})
+        product.with_context(lang='fr_FR').name = 'Chaise'
+
+        # Read back in each language
+        self.assertEqual(product.with_context(lang='en_US').name, 'Chair')
+        self.assertEqual(product.with_context(lang='fr_FR').name, 'Chaise')
+
+    def test_code_translation(self):
+        self.env['ir.module.module']._load_module_terms(
+            modules=['my_module'],
+            langs=['fr_FR'],
+        )
+        # _t() inside a method run in fr_FR context returns fr_FR string
+        msg = self.env['my.model'].with_context(lang='fr_FR')._hello()
+        self.assertEqual(msg, 'Bonjour')
+```
+
+### Asserting `get_field_translations`
+
+```python
+def test_get_field_translations(self):
+    product = self.env['my.product'].create({'name': 'Chair'})
+    product.update_field_translations('name', {'fr_FR': 'Chaise'})
+
+    translations, context = product.get_field_translations('name')
+    by_lang = {t['lang']: t['value'] for t in translations}
+
+    self.assertEqual(by_lang['en_US'], 'Chair')
+    self.assertEqual(by_lang['fr_FR'], 'Chaise')
+    self.assertEqual(context['translation_type'], 'char')
+```
+
+---
+
+## Quick Checklist
+
+When adding translatable content to an Odoo 16 module:
+
+- [ ] Python runtime strings wrapped in `_()`
+- [ ] Python module-level / class-level strings wrapped in `_lt()`
+- [ ] JavaScript/OWL strings wrapped in `_t()` (or `_lt()` for module-top-level)
+- [ ] Translatable field values declared with `translate=True` (or `html_translate`)
+- [ ] All `string=` / `help=` / `placeholder=` attributes present in views (auto-extracted)
+- [ ] `i18n/<module>.pot` present and up to date
+- [ ] Every shipped locale has a `.po` in `i18n/` derived from that `.pot`
+- [ ] Dynamic content uses `%(name)s` placeholders, never f-string / `+`
+- [ ] No `self.env['ir.translation']` usage (model removed in v16)
+- [ ] Tests cover at least one non-en_US language switch
+
+---
+
+## Key Files Reference
+
+| Purpose | File |
+|---------|------|
+| Core translation logic | `odoo/tools/translate.py` |
+| `_` / `_lt` Python helpers | `odoo/tools/translate.py` (`GettextAlias`, `_lt`) |
+| Field type definitions (JSONB column) | `odoo/fields.py` (`_String`, `Char`, `Text`, `Html`) |
+| `get_field_translations` / `update_field_translations` | `odoo/models.py` |
+| Language model | `odoo/addons/base/models/res_lang.py` |
+| JS translation utilities | `addons/web/static/src/core/l10n/translation.js` |
+| JS translation controller | `addons/web/controllers/webclient.py` |
+| Export wizard | `odoo/addons/base/wizard/base_export_language.py` |
+| Import wizard | `odoo/addons/base/wizard/base_import_language.py` |
+| Module term loader | `odoo/addons/base/models/ir_module.py` (`_load_module_terms`) |
+| Translation tests (upstream) | `odoo/addons/base/tests/test_translate.py` |
+| Base translation template | `odoo/addons/base/i18n/base.pot` |
+
+---
+
+## Base Code Reference
+
+- `odoo/tools/translate.py` - `_`, `_lt`, `TranslationImporter`, `TranslationModuleReader`, `code_translations`, `html_translate`, `xml_translate`
+- `odoo/fields.py` - translatable field JSONB storage (`_String.column_type`)
+- `odoo/models.py` - `BaseModel.get_field_translations`, `BaseModel.update_field_translations`, `BaseModel._update_field_translations`
+- `odoo/addons/base/models/res_lang.py` - `Lang._activate_lang`, `Lang._create_lang`, `Lang.get_installed`
+- `odoo/addons/base/models/ir_module.py` - `Module._load_module_terms`
+- `addons/web/static/src/core/l10n/translation.js` - `_t`, `_lt`, `LazyTranslatedString`

--- a/skills/odoo-16.0/references/odoo-16-view-guide.md
+++ b/skills/odoo-16.0/references/odoo-16-view-guide.md
@@ -1,0 +1,1220 @@
+---
+name: odoo-16-view
+description: Complete reference for Odoo 16 XML views, QWeb templates, and view inheritance. Covers tree, form, search, kanban, graph, pivot, calendar, activity, gantt views and Odoo 16 conventions.
+globs: "**/views/**/*.xml"
+topics:
+  - View types (tree, form, search, kanban, graph, pivot, calendar, activity, gantt)
+  - Tree view features (editable, decoration, optional fields, widgets)
+  - Form view structure (sheet, button box, notebook, chatter)
+  - Search view features (fields, filters, group by)
+  - Kanban view (color, progress, kanban-box templates)
+  - Dynamic attributes (attrs/states modifiers)
+  - View inheritance (xpath, position, shorthand)
+  - QWeb templates (t-esc, t-out, t-field)
+when_to_use:
+  - Writing Odoo 16 XML views
+  - Implementing view inheritance
+  - Building QWeb templates
+  - Migrating views from Odoo 16 to 17
+---
+
+# Odoo 16 View Guide
+
+Complete reference for Odoo 16 XML views, QWeb templates, and view inheritance.
+
+## Table of Contents
+
+1. [View Types](#view-types)
+2. [Tree View (List)](#tree-view-list)
+3. [Form View](#form-view)
+4. [Search View](#search-view)
+5. [Kanban View](#kanban-view)
+6. [Graph & Pivot Views](#graph--pivot-views)
+7. [Calendar View](#calendar-view)
+8. [Activity View](#activity-view)
+9. [Gantt View](#gantt-view)
+10. [Dynamic Attributes (attrs/states)](#dynamic-attributes)
+11. [View Inheritance](#view-inheritance)
+12. [QWeb Templates](#qweb-templates)
+13. [Complete Module Example](#complete-module-example)
+
+---
+
+## View Types
+
+Odoo 16 supports the following view types. The XML root tag matches the value stored in `ir.ui.view.type`.
+
+| Type | XML Tag | Use For |
+|------|---------|---------|
+| `tree` | `<tree>` | Table / list view (still `<tree>` in v16; renamed to `<list>` in v18) |
+| `form` | `<form>` | Single-record edit/view |
+| `search` | `<search>` | Search panel, filters, group-by |
+| `kanban` | `<kanban>` | Card-based view |
+| `graph` | `<graph>` | Bar/line/pie charts |
+| `pivot` | `<pivot>` | Pivot table |
+| `calendar` | `<calendar>` | Calendar view |
+| `gantt` | `<gantt>` | Gantt chart (enterprise) |
+| `activity` | `<activity>` | Activity view (requires `mail` module) |
+| `qweb` | `<template>` | QWeb template |
+
+Defined in `odoo/addons/base/models/ir_ui_view.py` (`VIEW_TYPES` and the `type` selection).
+
+---
+
+## Tree View (List)
+
+The Odoo 16 list view is declared with `<tree>`. (Odoo 18 renamed this tag to `<list>` — in v16 it is still `<tree>` everywhere, including in `xpath` expressions and action `view_mode` values such as `tree,form`.)
+
+### Basic Tree View
+
+```xml
+<record id="view_my_model_tree" model="ir.ui.view">
+    <field name="name">my.model.tree</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <tree string="My Records">
+            <field name="name"/>
+            <field name="date"/>
+            <field name="state"/>
+        </tree>
+    </field>
+</record>
+```
+
+### Tree View Features
+
+```xml
+<tree string="My Records"
+      sample="1"               <!-- Show sample data when empty -->
+      multi_edit="1"           <!-- Allow multi-record inline edit -->
+      editable="bottom"        <!-- "top" or "bottom" to enable inline edit -->
+      default_order="date desc"
+      limit="80"
+      create="true" edit="true" delete="true"
+      expand="1">              <!-- Auto-expand groups -->
+
+    <!-- Decoration (row styling via domain-style expression) -->
+    <field name="state"
+           decoration-success="state == 'done'"
+           decoration-danger="state == 'cancel'"
+           decoration-warning="state == 'pending'"
+           decoration-muted="not active"/>
+
+    <!-- Optional fields (user can toggle column) -->
+    <field name="phone" optional="show"/>   <!-- shown by default -->
+    <field name="mobile" optional="hide"/>  <!-- hidden by default -->
+
+    <!-- Specialized widgets -->
+    <field name="image" widget="image"/>
+    <field name="user_id" widget="many2one_avatar_user"/>
+    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+    <field name="sequence" widget="handle"/>   <!-- drag-to-reorder -->
+
+    <!-- Hidden technical column (still usable for decorations/computations) -->
+    <field name="currency_id" invisible="1"/>
+
+    <!-- Group restriction -->
+    <field name="company_id" groups="base.group_multi_company"/>
+
+    <!-- Inline button -->
+    <button name="action_confirm" type="object" string="Confirm"
+            states="draft"/>
+</tree>
+```
+
+### Decoration Types
+
+| Attribute | Effect | Typical Meaning |
+|-----------|--------|-----------------|
+| `decoration-bf` | Bold | Highlight |
+| `decoration-it` | Italic | Emphasis |
+| `decoration-danger` | Red text | Error / cancelled |
+| `decoration-warning` | Orange text | Warning |
+| `decoration-success` | Green text | Success / done |
+| `decoration-info` | Blue text | Informational |
+| `decoration-muted` | Grey text | Inactive / archived |
+| `decoration-primary` | Brand colour | Primary / featured |
+
+The value of each `decoration-*` is a Python expression evaluated against the record (e.g. `state == 'done'`).
+
+### Groupable / Hidden Columns
+
+- `invisible="1"` on a tree field hides the column while still loading the field for decorations or modifiers.
+- `attrs="{'column_invisible': [('parent.hide_amounts', '=', True)]}"` hides an entire x2many column based on the parent record.
+- `attrs="{'readonly': [('state', 'in', ('cancel', 'sale'))]}"` makes a row field read-only dynamically.
+
+---
+
+## Form View
+
+### Basic Form View
+
+```xml
+<record id="view_my_model_form" model="ir.ui.view">
+    <field name="name">my.model.form</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <form string="My Record">
+            <sheet>
+                <group>
+                    <group>
+                        <field name="name"/>
+                        <field name="date"/>
+                    </group>
+                    <group>
+                        <field name="user_id"/>
+                        <field name="company_id"/>
+                    </group>
+                </group>
+            </sheet>
+        </form>
+    </field>
+</record>
+```
+
+### Full Form Structure
+
+```xml
+<form string="My Record" create="true" edit="true" delete="true">
+
+    <!-- 1. Header: status bar + workflow buttons -->
+    <header>
+        <button name="action_confirm" type="object" string="Confirm"
+                class="btn-primary" states="draft"/>
+        <button name="action_done" type="object" string="Done"
+                states="confirmed"/>
+        <button name="action_cancel" type="object" string="Cancel"
+                attrs="{'invisible': [('state', 'in', ('done', 'cancel'))]}"/>
+        <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done"/>
+    </header>
+
+    <!-- 2. Sheet: main body -->
+    <sheet>
+
+        <!-- Ribbon (e.g. "Archived" badge) -->
+        <widget name="web_ribbon" title="Archived" bg_color="bg-danger"
+                attrs="{'invisible': [('active', '=', True)]}"/>
+
+        <!-- Stat buttons -->
+        <div class="oe_button_box" name="button_box">
+            <button name="action_view_related" type="object"
+                    class="oe_stat_button" icon="fa-tasks">
+                <field name="task_count" widget="statinfo" string="Tasks"/>
+            </button>
+        </div>
+
+        <!-- Image / avatar -->
+        <field name="image" widget="image" class="oe_avatar"/>
+
+        <!-- Title block -->
+        <div class="oe_title">
+            <h1>
+                <field name="name" placeholder="Record name..." required="1"/>
+            </h1>
+        </div>
+
+        <!-- Two-column group layout -->
+        <group>
+            <group>
+                <field name="partner_id"/>
+                <field name="date"/>
+                <field name="email" widget="email"/>
+            </group>
+            <group>
+                <field name="user_id"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="priority" widget="priority"/>
+            </group>
+        </group>
+
+        <!-- Notebook (tabs) -->
+        <notebook>
+            <page string="Lines" name="lines">
+                <field name="line_ids">
+                    <tree editable="bottom">
+                        <field name="product_id"/>
+                        <field name="quantity"/>
+                        <field name="price_unit"/>
+                        <field name="subtotal" sum="Total"/>
+                    </tree>
+                </field>
+            </page>
+            <page string="Notes" name="notes">
+                <field name="note" placeholder="Add internal notes..."/>
+            </page>
+            <page string="Admin" name="admin" groups="base.group_system">
+                <field name="debug_info" widget="ace" options="{'mode': 'python'}"/>
+            </page>
+        </notebook>
+    </sheet>
+
+    <!-- 3. Chatter (explicit div + fields in v16) -->
+    <div class="oe_chatter">
+        <field name="message_follower_ids"/>
+        <field name="activity_ids"/>
+        <field name="message_ids"/>
+    </div>
+</form>
+```
+
+> **Chatter (v16)**: you declare the chatter as a `<div class="oe_chatter">` containing the three mail fields. The shorthand `<chatter/>` tag was introduced in Odoo 18 and does **not** exist in v16.
+
+### Form Root Attributes
+
+| Attribute | Effect |
+|-----------|--------|
+| `string` | Default record label |
+| `create` / `edit` / `delete` | `"false"` to disable per-view |
+| `duplicate` | `"false"` disables the "Duplicate" action |
+| `js_class` | Replace controller with a registered JS class |
+
+### Field Widgets (Form)
+
+```xml
+<!-- Text -->
+<field name="description" widget="text"/>
+<field name="html_body" widget="html"/>
+
+<!-- Date / Datetime -->
+<field name="date" widget="date"/>
+<field name="deadline" widget="datetime"/>
+<field name="create_date" readonly="1" widget="relative"/>
+
+<!-- Specialized -->
+<field name="email" widget="email"/>
+<field name="phone" widget="phone" options="{'enable_sms': false}"/>
+<field name="website" widget="url"/>
+<field name="image" widget="image" class="oe_avatar"/>
+
+<!-- Many2one -->
+<field name="partner_id"
+       options="{'no_open': True, 'no_create': True, 'no_quick_create': True}"/>
+<field name="user_id" widget="many2one_avatar_user"/>
+
+<!-- Many2many -->
+<field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+<field name="category_ids" widget="many2many_checkboxes"/>
+
+<!-- Selection / status bar -->
+<field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done"/>
+<field name="priority" widget="priority"/>
+<field name="kanban_state" widget="state_selection"/>
+
+<!-- Boolean -->
+<field name="active" widget="boolean_toggle"/>
+
+<!-- Monetary -->
+<field name="amount_total" widget="monetary"
+       options="{'currency_field': 'currency_id'}"/>
+<field name="currency_id" invisible="1"/>
+
+<!-- Signature -->
+<field name="signature" widget="signature"/>
+
+<!-- Domain builder -->
+<field name="domain" widget="domain" options="{'model': 'res.partner'}"/>
+
+<!-- Code editor (Ace) -->
+<field name="arch" widget="ace" options="{'mode': 'xml'}"/>
+```
+
+### Field Common Attributes
+
+```xml
+<!-- Placeholder, required, readonly, groups -->
+<field name="name" placeholder="Enter name..." required="1"/>
+<field name="reference" readonly="1"/>
+<field name="internal_note" groups="base.group_user"/>
+
+<!-- Context / domain -->
+<field name="product_id"
+       context="{'default_type': 'service'}"
+       domain="[('sale_ok', '=', True)]"/>
+
+<!-- No label -->
+<field name="description" nolabel="1"/>
+
+<!-- Inline edit of relational field -->
+<field name="partner_id" options="{'always_reload': True}"/>
+```
+
+---
+
+## Search View
+
+### Basic Search View
+
+```xml
+<record id="view_my_model_search" model="ir.ui.view">
+    <field name="name">my.model.search</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <search string="Search My Model">
+            <field name="name"/>
+            <field name="partner_id"/>
+            <filter string="Active" name="active" domain="[('active','=',True)]"/>
+        </search>
+    </field>
+</record>
+```
+
+### Full Search View
+
+```xml
+<search string="Search Orders">
+
+    <!-- Searchable fields (appear in search bar autocomplete) -->
+    <field name="name" string="Reference"
+           filter_domain="['|', ('name', 'ilike', self), ('client_ref', 'ilike', self)]"/>
+    <field name="partner_id" operator="child_of"/>
+    <field name="date"/>
+
+    <!-- Domain filters -->
+    <filter string="My Orders" name="my_orders" domain="[('user_id', '=', uid)]"/>
+    <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
+
+    <separator/>
+
+    <!-- Date filters (domain expressions using context_today / relativedelta) -->
+    <filter string="Today" name="today"
+            domain="[('date', '=', context_today().strftime('%Y-%m-%d'))]"/>
+    <filter string="This Month" name="this_month"
+            domain="[('date', '&gt;=', (context_today() + relativedelta(day=1)).strftime('%Y-%m-%d')),
+                     ('date', '&lt;=', (context_today() + relativedelta(months=1, day=1, days=-1)).strftime('%Y-%m-%d'))]"/>
+
+    <separator/>
+
+    <!-- State filters -->
+    <filter string="Draft" name="draft" domain="[('state', '=', 'draft')]"/>
+    <filter string="Confirmed" name="confirmed" domain="[('state', '=', 'confirmed')]"/>
+
+    <!-- Archived toggle -->
+    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+
+    <!-- Group By section -->
+    <group expand="0" string="Group By">
+        <filter string="Salesperson" name="group_user" context="{'group_by': 'user_id'}"/>
+        <filter string="Customer" name="group_partner" context="{'group_by': 'partner_id'}"/>
+        <filter string="Status" name="group_state" context="{'group_by': 'state'}"/>
+        <filter string="Order Date" name="group_date" context="{'group_by': 'date:month'}"/>
+    </group>
+
+    <!-- Search panel (left-hand side filter tree/list) -->
+    <searchpanel>
+        <field name="category_id" enable_counters="1"/>
+        <field name="stage_id" select="multi" icon="fa-tasks"/>
+    </searchpanel>
+</search>
+```
+
+`date:month` groups by month (other granularities: `day`, `week`, `month`, `quarter`, `year`).
+
+`filter_domain` replaces the default field domain — handy for fuzzy "search many columns at once".
+
+`&gt;=` / `&lt;=` are XML entities for `>=` / `<=`.
+
+---
+
+## Kanban View
+
+### Basic Kanban (v16 uses `t-name="kanban-box"`)
+
+```xml
+<record id="view_my_model_kanban" model="ir.ui.view">
+    <field name="name">my.model.kanban</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <kanban default_group_by="state" sample="1">
+            <field name="name"/>
+            <field name="state"/>
+            <templates>
+                <t t-name="kanban-box">
+                    <div class="oe_kanban_card oe_kanban_global_click">
+                        <strong><field name="name"/></strong>
+                        <div><field name="state"/></div>
+                    </div>
+                </t>
+            </templates>
+        </kanban>
+    </field>
+</record>
+```
+
+> The v16 card template name is `kanban-box`. (Odoo 19 introduced `t-name="card"`; do not use that name in v16.)
+
+### Kanban with Colour, Priority, and Progress Bar
+
+```xml
+<kanban default_group_by="state"
+        class="o_kanban_small_column"
+        quick_create="true"
+        records_draggable="true"
+        group_create="true"
+        sample="1">
+
+    <field name="name"/>
+    <field name="color"/>
+    <field name="priority"/>
+    <field name="kanban_state"/>
+    <field name="user_id"/>
+    <field name="activity_ids"/>
+
+    <!-- Column-level progress bar -->
+    <progressbar field="kanban_state"
+                 colors='{"done": "success", "blocked": "danger", "normal": "200"}'/>
+
+    <templates>
+        <t t-name="kanban-box">
+            <div t-attf-class="oe_kanban_card oe_kanban_global_click
+                               oe_kanban_color_#{kanban_getcolor(record.color.raw_value)}">
+                <div class="o_kanban_record_top">
+                    <div class="o_kanban_record_headings">
+                        <strong class="o_kanban_record_title">
+                            <field name="name"/>
+                        </strong>
+                    </div>
+                    <field name="priority" widget="priority"/>
+                </div>
+
+                <div class="o_kanban_record_body">
+                    <field name="description"/>
+                </div>
+
+                <div class="o_kanban_record_bottom">
+                    <div class="oe_kanban_bottom_left">
+                        <field name="activity_ids" widget="kanban_activity"/>
+                        <field name="kanban_state" widget="state_selection"/>
+                    </div>
+                    <div class="oe_kanban_bottom_right">
+                        <img t-att-src="kanban_image('res.users', 'avatar_128', record.user_id.raw_value)"
+                             t-att-title="record.user_id.value"
+                             class="oe_kanban_avatar"/>
+                    </div>
+                </div>
+
+                <!-- Kanban contextual menu -->
+                <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
+                    <a role="button" class="dropdown-toggle o-no-caret btn"
+                       data-bs-toggle="dropdown" data-bs-display="static" href="#"
+                       aria-label="Dropdown menu" title="Dropdown menu">
+                        <span class="fa fa-ellipsis-v"/>
+                    </a>
+                    <div class="dropdown-menu" role="menu">
+                        <a role="menuitem" type="edit" class="dropdown-item">Edit</a>
+                        <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </templates>
+</kanban>
+```
+
+Useful helpers available inside the template:
+
+| Helper | Purpose |
+|--------|---------|
+| `kanban_getcolor(index)` | Map integer 0..11 to an `oe_kanban_color_*` CSS class |
+| `kanban_image(model, field, id)` | Build `/web/image/...` URL for an image field |
+| `record.<field>.value` | Formatted value |
+| `record.<field>.raw_value` | Raw value |
+| `widget.editable` / `widget.deletable` | Booleans for permissions |
+
+### Kanban Attributes
+
+| Attribute | Purpose |
+|-----------|---------|
+| `default_group_by` | Default grouping field |
+| `default_order` | Initial sort order |
+| `quick_create` | Show the "+" column quick-create |
+| `quick_create_view` | Alternative form view reference for quick-create |
+| `group_create` | Allow creating new groups |
+| `group_delete` / `group_edit` | Group-level permissions |
+| `records_draggable` | Drag records between groups |
+| `sample="1"` | Show sample data when empty |
+| `class` | CSS class (`o_kanban_small_column`, `o_kanban_mobile`, ...) |
+
+---
+
+## Graph & Pivot Views
+
+### Graph View
+
+```xml
+<record id="view_my_model_graph" model="ir.ui.view">
+    <field name="name">my.model.graph</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <graph string="Sales Analysis" type="bar" stacked="1" sample="1">
+            <field name="date" interval="month" type="row"/>
+            <field name="partner_id" type="row"/>
+            <field name="amount_total" type="measure"/>
+        </graph>
+    </field>
+</record>
+```
+
+| Graph attribute | Values |
+|-----------------|--------|
+| `type` | `bar`, `line`, `pie` |
+| `stacked` | `"1"` for stacked bars |
+| `order` | `asc` or `desc` on the measure |
+| `disable_linking` | `"1"` prevents drill-down on click |
+
+Field roles: `type="row"` (dimension), `type="col"` (secondary dimension), `type="measure"` (aggregated value).
+
+### Pivot View
+
+```xml
+<record id="view_my_model_pivot" model="ir.ui.view">
+    <field name="name">my.model.pivot</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <pivot string="Sales Analysis" sample="1" disable_linking="0">
+            <field name="date" interval="month" type="row"/>
+            <field name="partner_id" type="col"/>
+            <field name="amount_total" type="measure"/>
+            <field name="qty" type="measure"/>
+        </pivot>
+    </field>
+</record>
+```
+
+---
+
+## Calendar View
+
+```xml
+<record id="view_my_model_calendar" model="ir.ui.view">
+    <field name="name">my.model.calendar</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <calendar string="Meetings"
+                  date_start="start"
+                  date_stop="stop"
+                  color="partner_id"
+                  mode="month"
+                  quick_create="1">
+            <field name="name"/>
+            <field name="partner_id" avatar_field="image_128"/>
+        </calendar>
+    </field>
+</record>
+```
+
+| Attribute | Description |
+|-----------|-------------|
+| `date_start` | Start datetime field (required) |
+| `date_stop` | End datetime field |
+| `date_delay` | Duration field (alternative to `date_stop`) |
+| `color` | Field used to color events (many2one recommended) |
+| `mode` | `day`, `week`, `month`, `year` |
+| `all_day` | Boolean field toggling all-day events |
+| `quick_create` | Enable quick record creation from the calendar |
+
+---
+
+## Activity View
+
+The `<activity>` view requires the `mail` module. The model must inherit `mail.activity.mixin`.
+
+```xml
+<record id="view_my_model_activity" model="ir.ui.view">
+    <field name="name">my.model.activity</field>
+    <field name="model">my.model</field>
+    <field name="arch" type="xml">
+        <activity string="My Records">
+            <field name="name"/>
+            <templates>
+                <div t-name="activity-box">
+                    <img t-att-src="activity_image('res.users', 'avatar_128', record.user_id.raw_value)"
+                         t-att-title="record.user_id.value"
+                         class="rounded-circle"/>
+                    <div>
+                        <field name="name" display="full"/>
+                        <field name="partner_id" muted="1"/>
+                    </div>
+                </div>
+            </templates>
+        </activity>
+    </field>
+</record>
+```
+
+---
+
+## Gantt View
+
+The `<gantt>` view is part of Odoo Enterprise (web_gantt module).
+
+```xml
+<record id="view_project_gantt" model="ir.ui.view">
+    <field name="name">project.task.gantt</field>
+    <field name="model">project.task</field>
+    <field name="arch" type="xml">
+        <gantt string="Tasks"
+               date_start="date_start"
+               date_stop="date_end"
+               default_group_by="user_id"
+               color="stage_id"
+               progress="progress"
+               precision="{'day': 'hour:half', 'week': 'day:full', 'month': 'day:full'}">
+            <field name="name"/>
+        </gantt>
+    </field>
+</record>
+```
+
+---
+
+## Dynamic Attributes
+
+> **v16 note:** Odoo 16 uses legacy view modifiers: `attrs="{...}"` for client-side dynamic `invisible`, `readonly`, `required`, and `column_invisible`, plus `states="draft,confirmed"` as a shorthand for state-gated visibility. Direct attributes such as `invisible="1"` and `invisible="context.get('default_state')"` are accepted in 16.0, but only as static/context-time view modifiers — they are not evaluated against record field values. Python boolean expressions over field names (e.g. `invisible="state != 'draft'"`) are an Odoo 17+ syntax and are not supported in 16.0; use `attrs` for any modifier that must react to a field value.
+
+### attrs: invisible / readonly / required
+
+```xml
+<!-- Single-field condition -->
+<field name="company_name" attrs="{'invisible': [('is_company', '=', True)]}"/>
+<field name="email"        attrs="{'required': [('is_company', '=', True)]}"/>
+<field name="code"         attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+
+<!-- Compound domains: prefix operators use Odoo domain syntax -->
+<field name="phone" attrs="{'invisible': ['|', ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
+<button name="action_confirm" type="object" string="Confirm"
+        states="draft" class="btn-primary"/>
+
+<!-- In x2many tree views: column_invisible for an entire column -->
+<tree>
+    <field name="currency_id" invisible="1"/>
+    <field name="margin"
+           attrs="{'column_invisible': [('parent.show_margins', '=', False)]}"/>
+    <field name="amount" widget="monetary"/>
+</tree>
+
+<!-- Page (notebook tab) -->
+<page string="Contract" name="contract"
+      attrs="{'invisible': [('has_contract', '=', False)]}">
+    ...
+</page>
+
+<!-- Group / div -->
+<group attrs="{'invisible': [('partner_id', '=', False)]}">
+    <field name="partner_invoice_id"/>
+    <field name="partner_shipping_id"/>
+</group>
+```
+
+`attrs` values are dictionaries mapping a modifier name to a domain evaluated against the current record. Every field referenced by an `attrs` domain must be present in the view, often as `<field name="..." invisible="1"/>`. In x2many subviews, `parent.<field>` can be used in `column_invisible` domains.
+
+### Static / Context-Time Direct Attributes
+
+```xml
+<!-- Always hidden technical field -->
+<field name="active" invisible="1"/>
+
+<!-- Evaluated from the action/view context when the view is built -->
+<field name="source_id" invisible="context.get('default_state') == 'draft'"/>
+```
+
+Use direct attributes only when the value does not need to update as the user edits fields in the current record. If visibility/read-only/required must react to a field value in the form, use `attrs`.
+
+### `states` Shorthand
+
+```xml
+<!-- Visible only in draft and confirmed; requires a state field in the view -->
+<button name="action_confirm" type="object" string="Confirm"
+        states="draft,confirmed"/>
+```
+
+`states` is a shorthand for an invisible modifier on the `state` field. Avoid combining `states` and `attrs` on the same node unless the AND-combined result is intentional.
+
+### Migration To 17+ Direct Modifiers
+
+| Odoo 16 | Odoo 17+ |
+|---------|----------|
+| `attrs="{'invisible': [('state','=','done')]}"` | `invisible="state == 'done'"` |
+| `attrs="{'readonly': [('locked','=',True)]}"` | `readonly="locked"` |
+| `attrs="{'required': [('type','=','post')]}"` | `required="type == 'post'"` |
+| `attrs="{'invisible': [('a','=',1),('b','=',2)]}"` (AND) | `invisible="a == 1 and b == 2"` |
+| `attrs="{'invisible': ['\|',('a','=',1),('b','=',2)]}"` (OR) | `invisible="a == 1 or b == 2"` |
+| `states="draft,confirmed"` | `invisible="state not in ('draft','confirmed')"` |
+
+---
+
+## View Inheritance
+
+Inherited views are stored with `inherit_id` pointing to the parent view, and their `arch` contains spec nodes that describe where/what to modify.
+
+### XPath Inheritance
+
+```xml
+<record id="view_res_partner_form_inherit" model="ir.ui.view">
+    <field name="name">res.partner.form.inherit.my.module</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_partner_form"/>
+    <field name="arch" type="xml">
+
+        <!-- Insert AFTER an existing field -->
+        <xpath expr="//field[@name='email']" position="after">
+            <field name="my_custom_field"/>
+        </xpath>
+
+        <!-- Insert BEFORE an existing field -->
+        <xpath expr="//field[@name='name']" position="before">
+            <field name="prefix"/>
+        </xpath>
+
+        <!-- Insert INSIDE an element (at the end) -->
+        <xpath expr="//sheet/group[1]" position="inside">
+            <field name="extra_note"/>
+        </xpath>
+
+        <!-- REPLACE an element -->
+        <xpath expr="//field[@name='name']" position="replace">
+            <field name="name" required="1" placeholder="Name..."/>
+        </xpath>
+
+        <!-- REMOVE an element (replace with empty content) -->
+        <xpath expr="//field[@name='comment']" position="replace"/>
+
+        <!-- Modify ATTRIBUTES of an element -->
+        <xpath expr="//field[@name='name']" position="attributes">
+            <attribute name="readonly">1</attribute>
+            <attribute name="string">Full Name</attribute>
+        </xpath>
+
+        <!-- Append to attribute value (comma-separated) -->
+        <xpath expr="//field[@name='name']" position="attributes">
+            <attribute name="groups" add="base.group_system" separator=","/>
+        </xpath>
+
+        <!-- Move an existing element (see MOVE pattern below) -->
+        <xpath expr="//field[@name='email']" position="after">
+            <field name="phone" position="move"/>
+        </xpath>
+
+        <!-- Replace the ROOT tag (rare - used for top-level tree changes) -->
+        <xpath expr="//tree" position="attributes">
+            <attribute name="editable">bottom</attribute>
+        </xpath>
+    </field>
+</record>
+```
+
+> In v16 tree views, xpath expressions targeting the root list element use `//tree`, not `//list`.
+
+### Shorthand (Field / Tag Position)
+
+You can skip `<xpath>` when targeting a named field or a unique top-level tag:
+
+```xml
+<field name="arch" type="xml">
+    <!-- Equivalent to <xpath expr="//field[@name='email']" position="after"> -->
+    <field name="email" position="after">
+        <field name="my_field"/>
+    </field>
+
+    <!-- Target the tree root directly -->
+    <tree position="attributes">
+        <attribute name="editable">bottom</attribute>
+    </tree>
+
+    <!-- Target the form root -->
+    <form position="inside">
+        <div>Content appended at the end of &lt;form&gt;</div>
+    </form>
+</field>
+```
+
+### Position Values Summary
+
+| Position | Effect |
+|----------|--------|
+| `after` | Insert spec children right after the matched node |
+| `before` | Insert spec children right before the matched node |
+| `inside` (default) | Append spec children as last children of the matched node |
+| `replace` | Replace matched node with spec children (empty spec = remove) |
+| `attributes` | Add/change attributes on the matched node |
+| `move` | On a CHILD of an insertion spec, move an existing node into the new location |
+
+### Multiple Matches / Cascades
+
+Inherited views themselves can be inherited. The engine combines all `inherit_id` descendants ordered by `priority` (default 16, lower runs first) and applies specs sequentially.
+
+### Extending Inline Sub-Views
+
+The `<tree>` nested inside a `<field name="line_ids">` is also reachable via xpath:
+
+```xml
+<xpath expr="//field[@name='line_ids']/tree/field[@name='price_unit']" position="after">
+    <field name="discount"/>
+</xpath>
+```
+
+---
+
+## QWeb Templates
+
+QWeb powers reports, backend views (list/kanban/form templates), and website pages. Templates are `ir.ui.view` records of `type="qweb"`, usually written with the `<template>` shortcut.
+
+### Basic Template
+
+```xml
+<template id="my_module.landing_page" name="Landing Page">
+    <div class="container">
+        <h1 t-out="title"/>
+        <t t-if="records">
+            <ul>
+                <t t-foreach="records" t-as="rec">
+                    <li>
+                        <span t-field="rec.name"/>
+                        -
+                        <span t-esc="rec.date" t-options="{'widget': 'date'}"/>
+                    </li>
+                </t>
+            </ul>
+        </t>
+        <t t-else="">
+            <p>No records found.</p>
+        </t>
+    </div>
+</template>
+```
+
+### Output Directives
+
+| Directive | Purpose | Notes |
+|-----------|---------|-------|
+| `t-esc` | Output escaped text | Classic; still fully supported in v16 |
+| `t-out` | Output escaped text, but **respects `Markup`** | **Preferred** for trusted HTML / rich-text fields |
+| `t-field` | Output a record field with formatting | Uses field widget formatting |
+| `t-raw` | Output raw (unescaped) — **deprecated**, avoid | Use `t-out` with `Markup(...)` instead |
+
+```xml
+<!-- Plain text -->
+<span t-esc="record.name"/>
+<span t-out="record.name"/>
+
+<!-- Rich HTML field (safe) -->
+<div t-out="record.body_html"/>
+
+<!-- Field with formatting widget -->
+<span t-field="record.amount_total"
+      t-options='{"widget": "monetary", "display_currency": record.currency_id}'/>
+
+<!-- Conditional text -->
+<span t-esc="record.ref or 'Draft'"/>
+```
+
+### Control Flow
+
+```xml
+<t t-if="condition">true branch</t>
+<t t-elif="other_cond">elif branch</t>
+<t t-else="">else branch</t>
+
+<t t-foreach="docs" t-as="doc">
+    <div>
+        <span t-esc="doc_index"/>   <!-- index (0-based) -->
+        <span t-esc="doc_first"/>   <!-- True on first -->
+        <span t-esc="doc_last"/>    <!-- True on last -->
+        <span t-esc="doc_size"/>    <!-- total length -->
+    </div>
+</t>
+
+<!-- Set a variable -->
+<t t-set="total" t-value="sum(line.subtotal for line in doc.line_ids)"/>
+<span t-esc="total"/>
+```
+
+### Attribute Directives
+
+```xml
+<!-- Dynamic attribute value -->
+<a t-att-href="'/shop/%d' % product.id">View</a>
+
+<!-- Attribute from dict -->
+<div t-att="{'data-id': record.id, 'class': 'my-card'}"/>
+
+<!-- Format-string attribute -->
+<div t-attf-class="o_card color-#{record.color}"/>
+
+<!-- Conditional attribute -->
+<button t-att-disabled="'disabled' if readonly else None">Save</button>
+```
+
+### Template Inheritance
+
+```xml
+<template id="landing_page_inherit"
+          inherit_id="my_module.landing_page">
+    <xpath expr="//h1" position="after">
+        <p class="lead">Added via inheritance</p>
+    </xpath>
+</template>
+```
+
+### Calling Other Templates
+
+```xml
+<t t-call="web.external_layout">
+    <t t-set="doc" t-value="doc"/>
+    <div class="page">
+        <h2 t-field="doc.name"/>
+    </div>
+</t>
+```
+
+---
+
+## Complete Module Example
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!-- TREE -->
+        <record id="view_my_module_tree" model="ir.ui.view">
+            <field name="name">my.module.tree</field>
+            <field name="model">my.module</field>
+            <field name="arch" type="xml">
+                <tree string="My Modules" sample="1"
+                      decoration-success="state == 'done'"
+                      decoration-muted="state == 'cancel'">
+                    <field name="name"/>
+                    <field name="partner_id"/>
+                    <field name="date"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                    <field name="state" widget="badge"
+                           decoration-success="state == 'done'"
+                           decoration-info="state == 'draft'"/>
+                </tree>
+            </field>
+        </record>
+
+        <!-- FORM -->
+        <record id="view_my_module_form" model="ir.ui.view">
+            <field name="name">my.module.form</field>
+            <field name="model">my.module</field>
+            <field name="arch" type="xml">
+                <form string="My Module">
+                    <header>
+                        <button name="action_confirm" type="object"
+                                string="Confirm" class="btn-primary"
+                                states="draft"/>
+                        <button name="action_done" type="object"
+                                string="Mark Done"
+                                states="confirmed"/>
+                        <field name="state" widget="statusbar"
+                               statusbar_visible="draft,confirmed,done"/>
+                    </header>
+                    <sheet>
+                        <widget name="web_ribbon" title="Archived"
+                                bg_color="bg-danger"
+                                attrs="{'invisible': [('active', '=', True)]}"/>
+                        <div class="oe_button_box" name="button_box">
+                            <button name="action_view_lines" type="object"
+                                    class="oe_stat_button" icon="fa-list">
+                                <field name="line_count" widget="statinfo" string="Lines"/>
+                            </button>
+                        </div>
+                        <div class="oe_title">
+                            <h1><field name="name" placeholder="Record name..."/></h1>
+                        </div>
+                        <group>
+                            <group>
+                                <field name="partner_id"/>
+                                <field name="date"/>
+                            </group>
+                            <group>
+                                <field name="user_id"/>
+                                <field name="priority" widget="priority"/>
+                                <field name="active" invisible="1"/>
+                            </group>
+                        </group>
+                        <notebook>
+                            <page string="Lines" name="lines">
+                                <field name="line_ids">
+                                    <tree editable="bottom">
+                                        <field name="product_id"/>
+                                        <field name="quantity"/>
+                                        <field name="price_unit"/>
+                                        <field name="subtotal" sum="Total"/>
+                                    </tree>
+                                </field>
+                            </page>
+                            <page string="Notes" name="notes">
+                                <field name="note" nolabel="1"
+                                       placeholder="Internal notes..."/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids"/>
+                        <field name="activity_ids"/>
+                        <field name="message_ids"/>
+                    </div>
+                </form>
+            </field>
+        </record>
+
+        <!-- SEARCH -->
+        <record id="view_my_module_search" model="ir.ui.view">
+            <field name="name">my.module.search</field>
+            <field name="model">my.module</field>
+            <field name="arch" type="xml">
+                <search string="Search My Module">
+                    <field name="name"
+                           filter_domain="['|',('name','ilike',self),('partner_id','ilike',self)]"/>
+                    <filter string="My Records" name="my_records"
+                            domain="[('user_id','=',uid)]"/>
+                    <separator/>
+                    <filter string="Draft" name="draft" domain="[('state','=','draft')]"/>
+                    <filter string="Done"  name="done"  domain="[('state','=','done')]"/>
+                    <filter string="Archived" name="archived" domain="[('active','=',False)]"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Salesperson" name="group_user"
+                                context="{'group_by': 'user_id'}"/>
+                        <filter string="Status" name="group_state"
+                                context="{'group_by': 'state'}"/>
+                        <filter string="Date" name="group_date"
+                                context="{'group_by': 'date:month'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <!-- KANBAN -->
+        <record id="view_my_module_kanban" model="ir.ui.view">
+            <field name="name">my.module.kanban</field>
+            <field name="model">my.module</field>
+            <field name="arch" type="xml">
+                <kanban default_group_by="state" sample="1">
+                    <field name="name"/>
+                    <field name="state"/>
+                    <field name="user_id"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_card oe_kanban_global_click">
+                                <div class="o_kanban_record_top">
+                                    <strong><field name="name"/></strong>
+                                    <field name="priority" widget="priority"/>
+                                </div>
+                                <div class="o_kanban_record_bottom">
+                                    <field name="user_id" widget="many2one_avatar_user"/>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
+        <!-- ACTION -->
+        <record id="action_my_module" model="ir.actions.act_window">
+            <field name="name">My Modules</field>
+            <field name="res_model">my.module</field>
+            <field name="view_mode">tree,kanban,form</field>
+            <field name="search_view_id" ref="view_my_module_search"/>
+            <field name="context">{'search_default_my_records': 1}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">Create your first record</p>
+            </field>
+        </record>
+
+        <!-- MENU -->
+        <menuitem id="menu_my_module_root" name="My Module" sequence="50"/>
+        <menuitem id="menu_my_module"
+                  parent="menu_my_module_root"
+                  action="action_my_module"
+                  sequence="10"/>
+
+    </data>
+</odoo>
+```
+
+---
+
+## Common Anti-Patterns (v16)
+
+### Treating Odoo 17+ python-expr direct attributes as valid in v16
+
+```xml
+<!-- Odoo 17+ syntax only — NOT supported in 16.0 -->
+<field name="email" invisible="not is_company"/>
+<field name="code"  invisible="state not in ('draft','confirmed')"/>
+```
+
+In 16.0, use `attrs` / `states` for any modifier that must react to a field value:
+
+```xml
+<field name="email" attrs="{'invisible': [('is_company','=',False)]}"/>
+<field name="code"  states="draft,confirmed"/>
+```
+
+### Using `<list>` instead of `<tree>` in v16
+
+```xml
+<!-- Odoo 18+ only -->
+<list string="Records">...</list>
+```
+
+In v16 use `<tree>`:
+
+```xml
+<tree string="Records">...</tree>
+```
+
+This includes `view_mode` values on actions: **`tree,form`** (v16), not `list,form`.
+
+### Using `<chatter/>` shortcut (v18+)
+
+```xml
+<!-- Not available in v16 -->
+<chatter/>
+```
+
+Use the explicit v16 pattern:
+
+```xml
+<div class="oe_chatter">
+    <field name="message_follower_ids"/>
+    <field name="activity_ids"/>
+    <field name="message_ids"/>
+</div>
+```
+
+### Using `t-name="card"` in Kanban
+
+```xml
+<!-- Odoo 19 only -->
+<t t-name="card">...</t>
+```
+
+In v16 the kanban card template is always `kanban-box`:
+
+```xml
+<t t-name="kanban-box">...</t>
+```
+
+### Hard-coded primary-key domains in views
+
+```xml
+<!-- Brittle, will break between DBs -->
+<field name="partner_id" domain="[('id','=',42)]"/>
+```
+
+Use a meaningful domain or an XML-id reference in the action context instead.
+
+---
+
+## Base Code Reference
+
+All behaviour above is backed by the Odoo 16 source:
+
+- `odoo/addons/base/models/ir_ui_view.py` — view types and `apply_inheritance_specs`.
+- `odoo/addons/base/models/ir_actions.py` — `VIEW_TYPES`, `ir.actions.act_window.view_mode` (default `tree,form`).
+- `odoo/tools/convert.py` — XML data loader, shorthand processing for `<template>`, `<menuitem>`.
+- Real-world examples: `odoo/addons/base/views/*.xml`, `addons/sale/views/sale_order_views.xml`, `addons/mail/views/*.xml`.


### PR DESCRIPTION
### Context / issues

- The `agent-skills` repo has structured Odoo skill packs for newer versions, but Odoo 16.0 needs its own version-specific reference set so agents do not apply 17/18/19-only guidance to 16.0 code.
- Odoo 16 has important behavioral differences from newer versions, especially around XML view syntax, `<tree>` list views, chatter declaration, `group_operator=`, and legacy dynamic view modifiers.

### Scope

- This PR is scoped to adding and wiring the **Odoo 16.0** skill pack only.
- The new docs clarify Odoo 16-specific view modifier behavior:
  - Use `attrs="{...}"` / `states="..."` for client-side dynamic modifiers.
  - Direct `invisible="..."` attributes are accepted in 16.0 for static/context-time visibility, but are not record-reactive client modifiers.
- Provenance: the reference content is derived from Odoo 16 behavior and official/source-level conventions, adapted into this repository's skill format.
- Maintenance convention: Odoo 16 now follows the same `skills/odoo-<version>/` layout as the existing versioned Odoo skill packs, with README/plugin/agent metadata updated so review and tracer agents can resolve 16.0 explicitly.

### Change

- Adds a complete `skills/odoo-16.0/` skill tree with references for:
  - actions, controllers, data files, decorators, development workflow, fields, manifest, migrations, mixins, models, OWL, performance, reports, security, testing, transactions, translations, and views.
- Adds Odoo 16 operational entry points:
  - `SKILL.md`
  - `AGENTS.md`
  - `CLAUDE.md`
  - `references/api-highlights.md`
- Updates repository wiring:
  - README version references.
  - `.claude-plugin` metadata.
  - `odoo-code-review` and `odoo-code-tracer` agent guidance.
- Corrects Odoo 16 XML view guidance around dynamic modifiers, static/context-time direct attributes, `<tree>` usage, explicit chatter block, and `kanban-box`.

### Review notes

- This PR is intentionally large because it adds a full versioned documentation pack, but the scope is narrow: Odoo 16.0 only.
- No runtime code changes are included beyond metadata/agent wiring.