### PR TITLE
chore(release): 1.0.11 — Odoo 16 skill pack (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.11]
+
+### Release Description
+Added the `odoo-16.0` skill pack so the Odoo agents resolve 16.0 explicitly instead of applying 17/18/19-only guidance to Odoo 16 code.
+
+### Added
+- `skills/odoo-16.0/` — full Odoo 16 reference pack: `SKILL.md`, `AGENTS.md`, `CLAUDE.md`, `references/api-highlights.md`, and version-specific guides for actions, controllers, data files, decorators, development workflow, fields, manifest, migrations, mixins, models, OWL, performance, reports, security, testing, transactions, translations, and views.
+
+### Changed
+- `.claude-plugin` metadata and `README.md` register the Odoo 16.0 pack.
+- `agents/odoo-code-review/SKILL.md` and `agents/odoo-code-tracer/SKILL.md` are now version-aware for **16 / 17 / 18 / 19** (resolution order and supported-versions list include 16.0).
+
+### Notes
+- Supported version matrix: **16.0, 17.0, 18.0, 19.0**.
+- Adds #15.
+
 ## [1.0.10]
 
 ### Release Description

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unclecat/agent-skills-cli",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "CLI and docs for installing agent skills by version.",
   "bin": {
     "agent-skills": "bin/agent-skills.js"


### PR DESCRIPTION
## Mục đích
Cắt release **v1.0.11** cho PR #15 (Odoo 16 skill pack). Merge #15 không chạm `package.json`/`CHANGELOG.md` nên workflow Release chưa kích hoạt → Odoo 16 đã vào `main` nhưng chưa có tag.

## Thay đổi
- `package.json`: `1.0.10` → `1.0.11`.
- `CHANGELOG.md`: thêm section `## [1.0.11]` mô tả **chỉ** nội dung #15.

## Sau khi merge
Workflow `release.yml` (trigger khi `package.json`/`CHANGELOG.md` đổi trên `main`) sẽ tự: `npm test` → tạo tag `v1.0.11` + GitHub Release với notes lấy từ section CHANGELOG.

`npm test` đã chạy local: pass (gồm check "CHANGELOG.md has section for v1.0.11").