### PR TITLE
feat(ci): SkillSpector security scan, skill cleanup & gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,30 @@
-
+# OS
 .DS_Store
+Thumbs.db
+
+# Dependencies
+node_modules/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Claude harness (installed skills, auto-fetch cache, local config)
+.claude/
+
+# CI artifacts
+skillspector.sarif


### PR DESCRIPTION
## Tóm tắt

PR này merge `staging` → `main`, gồm 2 commit:

1. **CI security gate** — thêm job quét bảo mật skills bằng [NVIDIA SkillSpector](https://github.com/NVIDIA/skillspector), kèm baseline để chỉ fail khi có finding mới (risk > 50).
2. **Dọn repo** — loại bỏ các skill bị flag hoặc không dùng, và bổ sung `.gitignore` đầy đủ hơn.

## Thay đổi chính

### CI — `skill-security-scan`
- Job mới trong `.github/workflows/ci.yml`:
  - Cài SkillSpector qua `uv`
  - Quét `skills/` ở chế độ static (`--no-llm`, không cần API key)
  - So sánh với `.skillspector-baseline.yaml` — chỉ báo lỗi finding **mới**
  - Upload SARIF lên GitHub Code Scanning
- Thêm `.skillspector-baseline.yaml` với 59 finding đã chấp nhận (doc false-positive + cross-skill composition by-design)

### Gỡ skill khỏi plugin
Cập nhật `.claude-plugin/plugin.json`, xóa thư mục skill:
- `brainstorming`
- `mcp-builder`
- `payment-integration`
- `writing-skills`

**Giữ lại:** `code-review`, `dtg-base`, `odoo-17/18/19`, `slide`, agents & rules.

### `.gitignore`
- OS: `.DS_Store`, `Thumbs.db`
- Node: `node_modules/`, log files
- Secrets: `.env`, `.env.*`
- IDE: `.vscode/`, `.idea/`, swap files
- Claude harness: `.claude/` (skills đã cài, cache auto-fetch)
- CI artifacts: `skillspector.sarif`

## Thống kê
- **65 files** thay đổi
- **+300 / −15,810** dòng (chủ yếu do xóa `payment-integration`, `mcp-builder`, `writing-skills`)

## Test plan
- [ ] CI `validate` pass (`npm test`, JSON/YAML validation)
- [ ] CI `skill-security-scan` pass với baseline hiện tại
- [ ] CI `changelog-guard` không block (không bump version trong PR này)
- [ ] `.claude-plugin/plugin.json` chỉ liệt kê skill còn tồn tại trên disk
- [ ] `agent-skills` CLI cài plugin thành công sau merge

## Ghi chú vận hành
- Regenerate baseline sau thay đổi skill có chủ ý:
  ```bash
  skillspector baseline ./skills/ --no-llm
  ```
- Muốn quét sâu hơn: bỏ `--no-llm` và cấu hình LLM API key trong workflow.


Made with [Cursor](https://cursor.com)