### PR TITLE
chore(release): 1.0.13 — flow-diagram and odoo-commit skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,7 @@
     "skills": [
       "skills/code-review/SKILL.md",
       "skills/dtg-base/SKILL.md",
+      "skills/flow-diagram/SKILL.md",
       "skills/odoo-commit/SKILL.md",
       "skills/odoo-16.0/SKILL.md",
       "skills/odoo-17.0/SKILL.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.13]
+
+### Release Description
+Added two skill packs shipped on main after 1.0.12: interactive HTML+SVG flow diagrams, and Odoo-style commit workflow guidance.
+
+### Added
+- `skills/flow-diagram/` — self-contained interactive HTML+SVG flow/architecture diagrams (2-pane layout, zoom/pan, click-to-highlight flows with traveling dots and destination ping, light/dark theme, offline + browser collision checkers, layout-pattern guide, and a freight-logistics reference example).
+- `skills/odoo-commit/` — Odoo commit workflow: `[TAG] module:` subjects, amend-vs-new-commit decisions, explicit staging, `git commit -F`, and local history cleanup before PRs.
+- `.claude-plugin/plugin.json` and `README.md` register `odoo-commit`; SkillSpector baseline extended for flow-diagram static findings.
+
+### Notes
+- Closes the unreleased work from #21 and #22.
+
 ## [1.0.12]
 
 ### Release Description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,22 @@ All notable changes to this project will be documented in this file.
 ## [1.0.13]
 
 ### Release Description
-Added two skill packs shipped on main after 1.0.12: interactive HTML+SVG flow diagrams, and Odoo-style commit workflow guidance.
+This release packages two new skill packs that landed on `main` after 1.0.12, both aimed at day-to-day agent workflows rather than Odoo API reference alone.
+
+**Flow Diagram** teaches agents to produce one self-contained, interactive HTML+SVG page instead of a static Mermaid dump: 2-pane app layout (diagram + sidebar), fit-to-view with zoom/pan, click-to-highlight flows with traveling dots and destination ping rings, light/dark theme, brand logos from a bundled Simple Icons set, and a machine-checked draw → check → fix loop (browser + offline collision checkers). It ships a layout-patterns guide and a full freight-logistics reference example so the agent has a worked template to copy, not just prose rules.
+
+**Odoo Commit** fills a gap assistants often get wrong in Odoo repos: when to amend vs open a new commit, how to stage files explicitly (never `git add -A`), how to draft `[TAG] module: short description` subjects, and how to commit via `git commit -F` so history stays clean before a PR. The skill is wired into the Claude plugin manifest and README so it is discoverable next to the existing Odoo packs.
+
+Thank you to **Piruin Panichphol** ([@piruin](https://github.com/piruin)) for contributing the Odoo Commit skill (#21) — a thoughtful addition that makes commit hygiene in this repo match official Odoo git practice.
 
 ### Added
-- `skills/flow-diagram/` — self-contained interactive HTML+SVG flow/architecture diagrams (2-pane layout, zoom/pan, click-to-highlight flows with traveling dots and destination ping, light/dark theme, offline + browser collision checkers, layout-pattern guide, and a freight-logistics reference example).
-- `skills/odoo-commit/` — Odoo commit workflow: `[TAG] module:` subjects, amend-vs-new-commit decisions, explicit staging, `git commit -F`, and local history cleanup before PRs.
-- `.claude-plugin/plugin.json` and `README.md` register `odoo-commit`; SkillSpector baseline extended for flow-diagram static findings.
+- `skills/flow-diagram/` — interactive HTML+SVG flow/architecture diagrams (2-pane layout, zoom/pan, click-to-highlight flows with traveling dots and destination ping, light/dark theme, offline + browser collision checkers, layout-pattern guide, freight-logistics reference example).
+- `skills/odoo-commit/` — Odoo commit workflow: `[TAG] module:` subjects, amend-vs-new-commit decisions, explicit staging, `git commit -F`, and local history cleanup before PRs (thanks [@piruin](https://github.com/piruin)).
+- `.claude-plugin/plugin.json` and `README.md` register both skills; SkillSpector baseline extended for flow-diagram static findings.
 
 ### Notes
-- Closes the unreleased work from #21 and #22.
+- Ships unreleased work from #21 (odoo-commit) and #22 (flow-diagram).
+- Contributor credit: Piruin Panichphol — odoo-commit.
 
 ## [1.0.12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,19 @@ All notable changes to this project will be documented in this file.
 ## [1.0.13]
 
 ### Release Description
-This release packages two new skill packs that landed on `main` after 1.0.12, both aimed at day-to-day agent workflows rather than Odoo API reference alone.
-
-**Flow Diagram** teaches agents to produce one self-contained, interactive HTML+SVG page instead of a static Mermaid dump: 2-pane app layout (diagram + sidebar), fit-to-view with zoom/pan, click-to-highlight flows with traveling dots and destination ping rings, light/dark theme, brand logos from a bundled Simple Icons set, and a machine-checked draw → check → fix loop (browser + offline collision checkers). It ships a layout-patterns guide and a full freight-logistics reference example so the agent has a worked template to copy, not just prose rules.
-
-**Odoo Commit** fills a gap assistants often get wrong in Odoo repos: when to amend vs open a new commit, how to stage files explicitly (never `git add -A`), how to draft `[TAG] module: short description` subjects, and how to commit via `git commit -F` so history stays clean before a PR. The skill is wired into the Claude plugin manifest and README so it is discoverable next to the existing Odoo packs.
-
-Thank you to **Piruin Panichphol** ([@piruin](https://github.com/piruin)) for contributing the Odoo Commit skill (#21) — a thoughtful addition that makes commit hygiene in this repo match official Odoo git practice.
+Added two skill packs for day-to-day agent workflows: interactive HTML+SVG flow/architecture diagrams (`flow-diagram`), and Odoo-style commit guidance (`odoo-commit`) so assistants stage, amend, and message commits the way Odoo projects expect. Flow diagrams ship as one self-contained page with zoom/pan, click-to-highlight flows (traveling dots + destination ping), light/dark theme, collision checkers, a layout-patterns guide, and a freight-logistics reference example. Odoo Commit covers amend-vs-new-commit decisions, explicit staging, `[TAG] module:` subjects, and `git commit -F` before opening a PR.
 
 ### Added
-- `skills/flow-diagram/` — interactive HTML+SVG flow/architecture diagrams (2-pane layout, zoom/pan, click-to-highlight flows with traveling dots and destination ping, light/dark theme, offline + browser collision checkers, layout-pattern guide, freight-logistics reference example).
-- `skills/odoo-commit/` — Odoo commit workflow: `[TAG] module:` subjects, amend-vs-new-commit decisions, explicit staging, `git commit -F`, and local history cleanup before PRs (thanks [@piruin](https://github.com/piruin)).
-- `.claude-plugin/plugin.json` and `README.md` register both skills; SkillSpector baseline extended for flow-diagram static findings.
+- `skills/flow-diagram/` — interactive HTML+SVG flow/architecture diagrams: 2-pane layout, zoom/pan, click-to-highlight flows with traveling dots and destination ping, light/dark theme, offline + browser collision checkers, layout-pattern guide, and freight-logistics reference example.
+- `skills/odoo-commit/` — Odoo commit workflow: `[TAG] module:` subjects, amend-vs-new-commit decisions, explicit staging, `git commit -F`, and local history cleanup before PRs.
+
+### Changed
+- `.claude-plugin/plugin.json` and `README.md` register `flow-diagram` and `odoo-commit`; README inventory, stats, and current-release pointer updated for 1.0.13.
+- `.skillspector-baseline.yaml` extended for flow-diagram static-analysis findings accepted for this release.
 
 ### Notes
-- Ships unreleased work from #21 (odoo-commit) and #22 (flow-diagram).
-- Contributor credit: Piruin Panichphol — odoo-commit.
+- Ships #21 (`odoo-commit`) and #22 (`flow-diagram`).
+- Thank you to **Piruin Panichphol** ([@piruin](https://github.com/piruin)) for contributing the Odoo Commit skill.
 
 ## [1.0.12]
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ npx @unclecat/agent-skills-cli init --ai all --skill skills --version odoo-19.0
 
 Supported `--ai` targets: `cursor`, `claude`, `antigravity`, `kiro`, `docs`, `all`.
 
-Other installable packs: `code-review`, `dtg-base`, `odoo-commit`, `slide`.
+Other installable packs: `code-review`, `dtg-base`, `flow-diagram`, `odoo-commit`, `slide`.
 
 ### Option 3 — Claude Code plugin
 
-Install via the Claude plugin marketplace defined in [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json). The plugin bundles Odoo skill packs (16–19), code review, DTG Base, Odoo Commit, slide decks, and the Odoo review/tracer agents.
+Install via the Claude plugin marketplace defined in [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json). The plugin bundles Odoo skill packs (16–19), code review, DTG Base, Odoo Commit, Flow Diagram, slide decks, and the Odoo review/tracer agents.
 
 ---
 
@@ -164,6 +164,7 @@ In-depth guides written for AI consumption. Each Odoo pack includes 18 topic gui
 | **[Odoo 18.0](skills/odoo-18.0/)** | Odoo 18 development — `<list>` views, `aggregator=`, `<chatter/>` shortcut, ORM, security, OWL, reports, migrations, performance |
 | **[Odoo 19.0](skills/odoo-19.0/)** | Odoo 19 development — optional `_name`, `models.Constraint` / `models.Index`, current view and frontend conventions |
 | **[Odoo Commit](skills/odoo-commit/)** | Guides Odoo-style commit creation — message drafting, amend-vs-new-commit decisions, explicit staging, `git commit -F`, and local history cleanup before PRs |
+| **[Flow Diagram](skills/flow-diagram/)** | Interactive self-contained HTML+SVG flow/architecture diagrams — zoom/pan, click-to-highlight flows, traveling dots, collision checkers |
 | **[DTG Base](skills/dtg-base/)** | DTGBase utilities — date/period, timezone, batch processing, barcode, Vietnamese text, file helpers |
 | **[Code Review](skills/code-review/)** | Receiving feedback, requesting reviews, and verification gates for evidence-based development |
 | **[Slide (AI Vibe Slides)](skills/slide/)** | Self-contained HTML/React slide decks for fullscreen presentation |
@@ -227,6 +228,7 @@ agent-skills/
 │   ├── odoo-18.0/             # Odoo 18 guides + api-highlights
 │   ├── odoo-19.0/             # Odoo 19 guides + api-highlights
 │   ├── odoo-commit/           # Odoo-style commit workflow and message guidance
+│   ├── flow-diagram/          # Interactive HTML+SVG flow/architecture diagrams
 │   ├── dtg-base/              # DTGBase utilities
 │   ├── code-review/           # Code review workflow
 │   └── slide/                 # HTML/React slide decks
@@ -290,10 +292,10 @@ flowchart LR
 |--------|-------|
 | Documentation | ~57,000 lines |
 | Odoo skill packs | 4 (16.0, 17.0, 18.0, 19.0) |
-| Other skill packs | 4 (DTG Base, Code Review, Odoo Commit, Slide) |
+| Other skill packs | 5 (DTG Base, Code Review, Odoo Commit, Flow Diagram, Slide) |
 | Agents | 3 (Odoo Code Review, Odoo Code Tracer, Planner) |
 | Rules | 2 (Coding Style, Security) |
-| Current release | [1.0.12](CHANGELOG.md) |
+| Current release | [1.0.13](CHANGELOG.md) |
 | License | MIT |
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unclecat/agent-skills-cli",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "CLI and docs for installing agent skills by version.",
   "bin": {
     "agent-skills": "bin/agent-skills.js"


### PR DESCRIPTION
## Summary
- Bump to **1.0.13** with CHANGELOG in the same shape as 1.0.11/1.0.12 (`Release Description` → `Added` → `Changed` → `Notes`).
- Documents `flow-diagram` (#22) and `odoo-commit` (#21); thanks **Piruin Panichphol** ([@piruin](https://github.com/piruin)) under Notes.
- Registers `flow-diagram` in plugin manifest + README.
- On merge, `release.yml` creates GitHub release **v1.0.13** from the CHANGELOG section.

## Layout example (from `flow-diagram`)

https://github.com/user-attachments/assets/96c4c22d-dbe0-4145-bec3-e980b2a9dd5b

## Test plan
- [x] `npm test` — CHANGELOG section for 1.0.13 present
- [x] Heading `## [1.0.13]` matches what `release.yml` parses
- [ ] CI green on this PR
- [ ] After merge: tag `v1.0.13` + release notes match CHANGELOG