### PR TITLE
Fix odoo-19.0 reference guide inaccuracies

### DIFF
--- a/skills/odoo-19.0/references/odoo-19-actions-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-actions-guide.md
@@ -87,7 +87,7 @@ When defining actions from XML data files:
 | Attribute | Description |
 |-----------|-------------|
 | `view_mode` | Comma-separated list of view types (e.g., `list,form`) |
-| `view_ids` | Many2many to view objects |
+| `view_ids` | One2many to view objects (`ir.actions.act_window.view`, via `act_window_id`) |
 | `view_id` | Specific view to add to views list |
 
 ### Using ir.actions.act_window.view

--- a/skills/odoo-19.0/references/odoo-19-controller-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-controller-guide.md
@@ -83,12 +83,12 @@ def hello(self):
 | Parameter | Description                                    |
 | --------- | ---------------------------------------------- |
 | `route`   | Route path(s) (string or list)                 |
-| `auth`    | Authentication type (`public`, `user`, `none`) |
-| `methods` | Allowed HTTP methods (`GET`, `POST`, etc.)     |
-| `type`    | Response type (`http`, `json`)                 |
-| `website` | Boolean: bind to current website               |
-| `csrf`    | Boolean: CSRF protection (default: True)       |
-| `sitemap` | Boolean or sitemap config                      |
+| `auth`    | Authentication type (`public`, `user`, `none`, `bearer`) |
+| `methods` | Allowed HTTP methods (`GET`, `POST`, etc.)               |
+| `type`    | Response type (`http`, `jsonrpc`)                        |
+| `website` | Boolean: bind to current website                         |
+| `csrf`    | Boolean: CSRF protection (default: enabled for `http`, disabled for `jsonrpc`) |
+| `sitemap` | Boolean or sitemap config                                |
 
 ### Multiple Routes
 
@@ -101,11 +101,11 @@ def hello_bonjour(self):
 ### HTTP Methods
 
 ```python
-@http.route('/api/data', methods=['GET'], auth='user', type='json')
+@http.route('/api/data', methods=['GET'], auth='user', type='jsonrpc')
 def get_data(self):
     return {'data': 'value'}
 
-@http.route('/api/data', methods=['POST'], auth='user', type='json')
+@http.route('/api/data', methods=['POST'], auth='user', type='jsonrpc')
 def post_data(self, **kwargs):
     return {'result': 'created'}
 ```
@@ -120,8 +120,10 @@ def post_data(self, **kwargs):
 | --------- | ----------------------------- |
 | `public`  | No authentication required    |
 | `user`    | Requires active user session  |
+| `bearer`  | Authenticated via `Authorization: Bearer` API token header; falls back to `user` session if header is absent |
 | `none`    | No authentication, no session |
-| `website` | Public with website support   |
+
+Website routes are not a distinct `auth` value: use `auth='public'` (or `'user'`) together with `website=True`.
 
 ### Examples
 
@@ -137,7 +139,7 @@ def user_page(self):
     return "Only logged users can see this"
 
 # No authentication
-@http.route('/api/status', auth='none', type='json')
+@http.route('/api/status', auth='none', type='jsonrpc')
 def status(self):
     return {'status': 'ok'}
 ```
@@ -211,7 +213,7 @@ def html_response(self):
     return "<h1>Hello</h1>"
 
 # JSON response
-@http.route('/json', auth='public', type='json')
+@http.route('/json', auth='public', type='jsonrpc')
 def json_response(self):
     return {'key': 'value'}
 ```
@@ -236,7 +238,7 @@ def download_file(self):
         ('Content-Type', 'application/pdf'),
         ('Content-Disposition', 'attachment; filename="file.pdf"'),
     ]
-    return request.make_response(
+    return http.request.make_response(
         file_content,
         headers
     )
@@ -249,7 +251,7 @@ def download_file(self):
 ### JSON Controller
 
 ```python
-@http.route('/api/search', auth='user', type='json', methods=['POST'])
+@http.route('/api/search', auth='user', type='jsonrpc', methods=['POST'])
 def json_search(self, model, domain, fields=None):
     Model = http.request.env[model]
     records = Model.search(domain)
@@ -335,7 +337,7 @@ def sensitive(self):
 
 ### CSRF Protection
 
-CSRF is enabled by default for POST. Disable with caution:
+CSRF is enabled by default for `type='http'` routes and disabled by default for `type='jsonrpc'` routes. Disable with caution:
 
 ```python
 @http.route('/webhook', auth='public', methods=['POST'], csrf=False)

--- a/skills/odoo-19.0/references/odoo-19-decorator-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-decorator-guide.md
@@ -118,7 +118,7 @@ def _set_document(self):
     for record in self:
         if not record.document:
             continue
-        with open(record.document_path) as f:
+        with open(record.document_path, "w", encoding="utf-8") as f:
             f.write(record.document)
 ```
 

--- a/skills/odoo-19.0/references/odoo-19-development-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-development-guide.md
@@ -507,7 +507,7 @@ def action_open_wizard(self):
 ```python
 state = fields.Selection([
     ('draft', 'Draft'),
-    'confirmed', 'Confirmed'),
+    ('confirmed', 'Confirmed'),
     ('done', 'Done'),
 ], string='State', default='draft', tracking=True)
 ```

--- a/skills/odoo-19.0/references/odoo-19-field-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-field-guide.md
@@ -263,7 +263,7 @@ partner_id = fields.Many2one(
     required=True,
     ondelete='cascade',
     domain=[('customer_rank', '>', 0)],
-    default=lambda self: self.env.partner,
+    default=lambda self: self.env.user.partner_id,
 )
 ```
 

--- a/skills/odoo-19.0/references/odoo-19-mixins-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-mixins-guide.md
@@ -247,14 +247,11 @@ class MyModel(models.Model):
         required=True,
     )
 
-    def get_alias_model_name(self, vals):
-        return self._name
-
-    def get_alias_values(self):
-        values = super().get_alias_values()
-        values.update({
-            'alias_defaults': 'name',
-        })
+    def _alias_get_creation_values(self):
+        values = super()._alias_get_creation_values()
+        values['alias_model_id'] = self.env['ir.model']._get_id(self._name)
+        if self.id:
+            values['alias_defaults'] = {'name': self.name}
         return values
 ```
 

--- a/skills/odoo-19.0/references/odoo-19-model-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-model-guide.md
@@ -520,21 +520,25 @@ env.lang        # Current language
 
 ### Altering Environment
 
+Each of these returns a **new** recordset bound to the modified environment; the
+original recordset is unchanged. Always use the return value (assign it or chain
+the next call on it).
+
 ```python
 # Change context
-records.with_context(lang='fr_FR')
+records_fr = records.with_context(lang='fr_FR')
 
 # Change user
-records.with_user(user_id)
+records_as_user = records.with_user(user_id)
 
 # Change company
-records.with_company(company_id)
+records_for_company = records.with_company(company_id)
 
 # Change environment completely
-records.with_env(new_env)
+records_new_env = records.with_env(new_env)
 
 # Sudo (superuser mode)
-records.sudo()
+records_sudo = records.sudo()
 ```
 
 ---

--- a/skills/odoo-19.0/references/odoo-19-owl-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-owl-guide.md
@@ -40,6 +40,7 @@ import { Component } from "@odoo/owl";
 export class MyComponent extends Component {
   static template = "my_module.MyComponent";
   static props = {
+    title: { type: String, optional: true },
     value: { type: String, optional: true },
   };
 
@@ -236,7 +237,10 @@ increment() {
 ```javascript
 setup() {
     this.state = useState({count: 0});
-    this.double = computed(() => this.state.count * 2);
+}
+
+get double() {
+    return this.state.count * 2;
 }
 ```
 

--- a/skills/odoo-19.0/references/odoo-19-performance-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-performance-guide.md
@@ -100,7 +100,11 @@ def _compute_count(self):
 def _compute_count(self):
     domain = [('related_id', 'in', self.ids)]
     counts_data = other_model._read_group(domain, ['related_id'], ['__count'])
-    mapped_data = {r['related_id'][0]: r['__count'] for r in counts_data}
+    mapped_data = {
+        related.id: count
+        for related, count in counts_data
+        if related
+    }
     for record in self:
         record.count = mapped_data.get(record.id, 0)
 ```

--- a/skills/odoo-19.0/references/odoo-19-security-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-security-guide.md
@@ -367,17 +367,25 @@ domain = literal_eval(self.filter_domain)
 
 ### Accessing Object Attributes
 
-Use `__getitem__` instead of `getattr()` for dynamic field access.
+Use `__getitem__` instead of `getattr()` for dynamic field access. `record[state_field]`
+blocks arbitrary method access, but it still returns the value of *any* field on the
+model. If `state_field` comes from an untrusted caller, also validate it against a
+fixed allowlist and avoid `sudo()` unless the caller's access to that specific field
+is already established.
 
 ```python
-# BAD: unsafe, can access any attribute
+# BAD: unsafe, can access any attribute (including methods) and any field
 def _get_state_value(self, res_id, state_field):
     record = self.sudo().browse(res_id)
     return getattr(record, state_field, False)
 
-# GOOD: safer
+# GOOD: blocks method access, restricts fields to an allowlist, no unconditional sudo()
+ALLOWED_STATE_FIELDS = {'state', 'stage_id'}
+
 def _get_state_value(self, res_id, state_field):
-    record = self.sudo().browse(res_id)
+    if state_field not in ALLOWED_STATE_FIELDS:
+        raise ValueError(f"Field {state_field!r} is not allowed")
+    record = self.browse(res_id)
     return record[state_field]
 ```
 

--- a/skills/odoo-19.0/references/odoo-19-testing-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-testing-guide.md
@@ -235,28 +235,28 @@ order = form.save()
 
 Odoo uses Hoot for JS unit testing. See the frontend testing documentation.
 
-Test files go in `static/tests/`:
+Test files go in `static/tests/` and are named `*.test.js`:
 
 ```
 your_module/
 └── static/
     └── tests/
-        └── my_test.js
+        └── my_test.test.js
 ```
 
 ```javascript
-import { start } from '@mail/utils/test_utils';
+import { describe, expect, test } from "@odoo/hoot";
+import { defineModels, fields, models } from "@web/../tests/web_test_helpers";
 
-QUnit.module('My Module', {
-    beforeEach() {
-        this.data = {
-            records: {
-                'my.model': [{id: 1, name: 'Test'}],
-            },
-        };
-    },
-}, function () {
-    QUnit.test('my test', async function (assert) {
+class MyModel extends models.Model {
+    name = fields.Char();
+}
+
+defineModels([MyModel]);
+
+describe("My Module", () => {
+    test("my test", async () => {
+        expect(true).toBe(true);
         // Test code here
     });
 });

--- a/skills/odoo-19.0/references/odoo-19-transaction-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-transaction-guide.md
@@ -154,11 +154,22 @@ self.env.cr.execute("SELECT id FROM my_model WHERE id IN %s FOR UPDATE", (tuple(
 
 ### Auto Commit
 
-Odoo auto-commits after successful operations.
+Odoo commits the transaction once at the end of a successful request or job
+(controller call, RPC call, cron job), not immediately after each ORM call. If
+an exception is raised before that boundary, the whole transaction is rolled
+back, undoing every write made since it started.
 
 ```python
-# Transaction is auto-committed
-record.write({'field': 'value'})
+from odoo import http
+from odoo.http import request
+
+class MyController(http.Controller):
+    @http.route('/process', auth='user', type='jsonrpc')
+    def process(self, record_id):
+        record = request.env['my.model'].browse(record_id)
+        record.write({'field': 'value'})
+        # No manual commit here: Odoo commits automatically when this
+        # request completes successfully.
 ```
 
 ### Recoverable Work

--- a/skills/odoo-19.0/references/odoo-19-view-guide.md
+++ b/skills/odoo-19.0/references/odoo-19-view-guide.md
@@ -158,17 +158,7 @@ Guide for creating views in Odoo 19: list, form, search, kanban, calendar, graph
 
 ### Chatter
 
-```xml
-<form string="My Model">
-    <chatter>
-    <sheet>
-        <!-- Form content -->
-    </sheet>
-    </chatter>
-</form>
-```
-
-Or use shortcut:
+`<chatter/>` must be a direct sibling of `<sheet>`, not a wrapper around it:
 
 ```xml
 <form string="My Model">
@@ -184,8 +174,8 @@ Or use shortcut:
 ```xml
 <form string="My Model">
     <header>
-        <button name="action_confirm" string="Confirm" type="object" states="draft"/>
-        <button name="action_done" string="Done" type="object" states="confirmed"/>
+        <button name="action_confirm" string="Confirm" type="object" invisible="state != 'draft'"/>
+        <button name="action_done" string="Done" type="object" invisible="state != 'confirmed'"/>
         <field name="state" widget="statusbar"/>
     </header>
     <sheet>


### PR DESCRIPTION
Found while using the odoo-19.0 skill pack on a real Odoo 19 project and cross-checking its examples against the actual Odoo 19 source. 15 fixes across 13 files:

- `odoo-19-actions-guide.md`: `view_ids` documented as Many2many, it's actually a One2many (`act_window_id` inverse)
- `odoo-19-controller-guide.md`: `type='json'` renamed to `'jsonrpc'` in Odoo 19; added the `bearer` auth type; `website` isn't a real `auth` value; `request.make_response` should be `http.request.make_response`; CSRF default depends on route type
- `odoo-19-decorator-guide.md`: file opened read-only then written to
- `odoo-19-development-guide.md`: malformed Selection field tuple (missing open paren)
- `odoo-19-field-guide.md`: `self.env.partner` doesn't exist, should be `self.env.user.partner_id`
- `odoo-19-mixins-guide.md`: `get_alias_model_name`/`get_alias_values` aren't real hooks, the actual method is `_alias_get_creation_values`
- `odoo-19-model-guide.md`: `with_context`/`with_user`/`with_company`/`with_env`/`sudo()` examples ignored the returned recordset (these don't mutate in place)
- `odoo-19-owl-guide.md`: template referenced a `title` prop that wasn't declared; `computed()` isn't exported by `@odoo/owl`, replaced with a getter
- `odoo-19-performance-guide.md`: `_read_group` with `__count` returns tuples, not dicts
- `odoo-19-security-guide.md`: `record[state_field]` still allows reading any field on the model; added an allowlist and dropped the unconditional `sudo()`
- `odoo-19-testing-guide.md`: QUnit-based JS test example, QUnit was removed years ago; replaced with a Hoot-based example
- `odoo-19-transaction-guide.md`: auto-commit described as happening after each ORM call; it actually happens once at the end of a successful request/job
- `odoo-19-view-guide.md`: `<chatter>` shown wrapping `<sheet>` (the view compiler discards that); `states=` button attribute, removed since Odoo 17

Each fix was checked against the real Odoo 19 source (community and enterprise) before being applied.